### PR TITLE
It is possible for image tags not to have a 'src' (or background-image) ...

### DIFF
--- a/src/Preload.js
+++ b/src/Preload.js
@@ -250,7 +250,10 @@ html2canvas.Preload = function(element, opts){
     
     // load <img> images
     for (i = 0; i < imgLen; i+=1){
-        methods.loadImage( domImages[i].getAttribute( "src" ) );
+        var imgSrc = domImages[i].getAttribute( "src" );
+        if ( imgSrc ) {
+            methods.loadImage( imgSrc );   
+        }        
     }
     
     // remove 'start'


### PR DESCRIPTION
...attribute specified.  This case currently crashes html2canvas.  I know its an edge case but it bit me.  I set the image src programatically much later (element is actually not visible at the time I call html2canvas).
