### PR TITLE
fix origin check in IE

### DIFF
--- a/src/Preload.js
+++ b/src/Preload.js
@@ -12,7 +12,7 @@ html2canvas.Preload = function(element, opts){
         "proxy": "http://html2canvas.appspot.com/"
     },
     images = [],
-    pageOrigin = window.location.protocol + window.location.host,
+    pageOrigin,
     imagesLoaded = 0,
     methods,
     i,
@@ -22,6 +22,8 @@ html2canvas.Preload = function(element, opts){
     imgLen = domImages.length,
     link = doc.createElement("a");
     
+    link.href = window.location.href;
+    pageOrigin  = link.protocol + link.host;
     opts = opts || {};
     
     options = html2canvas.Util.Extend(opts, options);
@@ -32,8 +34,8 @@ html2canvas.Preload = function(element, opts){
     
     function isSameOrigin(url){
         link.href = url;
-        return ((link.protocol + link.host) === pageOrigin);
-        
+        var origin = link.protocol + link.host;
+        return ":" === origin || (origin === pageOrigin);
     }
     
     function getIndex(array,src){


### PR DESCRIPTION
The Image proxy was used more often than necessary relative URIs made the origin of an image ":" in IE9.
