### PR TITLE
clear canvas before rendering to allow jpeg export

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -11,7 +11,7 @@ var html2canvas = {};
 html2canvas.logging = true;
 
 html2canvas.log = function (a) {    
-    if (html2canvas.logging) {    
+    if (html2canvas.logging && window.console && window.console.log) {
         window.console.log(a);
     }
 };    

--- a/src/Parse.js
+++ b/src/Parse.js
@@ -47,6 +47,7 @@ html2canvas.Parse = function (element, images, opts) {
     children,
     childrenLen;
     
+    options = html2canvas.Util.Extend(opts, options);
 
     images = images || [];
     

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -78,12 +78,17 @@ html2canvas.Renderer = function(parseQueue, opts){
         queueLen,
         a,
         storageLen,
-        renderItem;
+        renderItem,
+        fstyle;
       
         canvas.width = options.width || zStack.ctx.width;   
         canvas.height = options.height || zStack.ctx.height;
     
-          
+        fstyle = ctx.fillStyle;
+        ctx.fillStyle = "#fff";
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = fstyle;
+
         for (i = 0, queueLen = queue.length; i < queueLen; i+=1){
             
             storageContext = queue.splice(0, 1)[0];


### PR DESCRIPTION
- normally when exporting jpeg any pixel that was transparent
  becomes black, make them white
  - check for window.console.log before use (avoid crash)
  - html2canvas.Parse: fix missing call to html2canvas.Util.Extend for the
    given options
