### PR TITLE
Fix for gradient parsing (when step positions are specified)

### DIFF
--- a/src/Generate.js
+++ b/src/Generate.js
@@ -31,7 +31,7 @@ html2canvas.Generate.Gradient = function(src, bounds) {
     canvas.height = bounds.height;
     
 
-    function getColors(input) {
+    function getColors(input) {      
         var j = -1, 
         color = '', 
         chr;
@@ -39,14 +39,18 @@ html2canvas.Generate.Gradient = function(src, bounds) {
         while( j++ < input.length ) {
             chr = input.charAt( j );
             if (chr === ')') {
-                color += chr;
+                color += chr;                
                 steps.push( color );
                 color = '';
                 j+=2;
-            } else {
+            } else if (color || isValidColorStartChar(chr)) {                
                 color += chr;
             }
         }
+    }
+    
+    function isValidColorStartChar(c) {     
+    	return c && /[^0-9%,]/.test(c);
     }
     
     if ( tmp = src.match(/-webkit-linear-gradient\((.*)\)/) ) {


### PR DESCRIPTION
This fixes an exception when trying to parse gradient like: 'rgb(254, 254, 254) 0%, rgb(236, 236, 236) 100%'

Note: This does not parse the % which would be good to delineate steps correctly, just a fix for an Exception.
