### PR TITLE
fixes NS_ERROR_OUT_OF_MEMORY exception

### DIFF
--- a/src/Generate.js
+++ b/src/Generate.js
@@ -331,8 +331,8 @@ _html2canvas.Generate.Gradient = function(src, bounds) {
     ctx = canvas.getContext('2d'),
     gradient, grad, i, len, img;
     
-    canvas.width = bounds.width;
-    canvas.height = bounds.height;
+    canvas.width = Math.min(bounds.width, 3000);
+    canvas.height = Math.min(bounds.height, 3000);
     
     // TODO: add support for multi defined background gradients (like radial gradient example in background.html)
     gradient = _html2canvas.Generate.parseGradient(src, bounds);

--- a/src/renderers/Canvas.js
+++ b/src/renderers/Canvas.js
@@ -198,8 +198,8 @@ _html2canvas.Renderer.Canvas = function( options ) {
                     // crop image to the bounds of selected (single) element
                     bounds = _html2canvas.Util.Bounds( options.elements[ 0 ] );
                     newCanvas = doc.createElement('canvas');
-                    newCanvas.width = bounds.width;
-                    newCanvas.height = bounds.height;
+                    newCanvas.width = Math.min(bounds.width, 3000);
+                    newCanvas.height = Math.min(bounds.height, 3000);
                     ctx = newCanvas.getContext("2d");
                 
                     ctx.drawImage( canvas, bounds.left, bounds.top, bounds.width, bounds.height, 0, 0, bounds.width, bounds.height );


### PR DESCRIPTION
This fixes mozilla failure code: 0x8007000e (NS_ERROR_OUT_OF_MEMORY) [nsIDOMHTMLCanvasElement.width] when trying to render a div with 10.000 pixels in width.
