### PR TITLE
Misc fixes

### DIFF
--- a/src/Parse.js
+++ b/src/Parse.js
@@ -1008,6 +1008,10 @@ _html2canvas.Parse = function ( images, options ) {
             docDim = {};
         }
 
+        // if the body has no background color or a transparent one, make it white
+        if( el.nodeName == "BODY" && (bgcolor=="rgba(0, 0, 0, 0)" || bgcolor=="transparent") ){
+          bgcolor = "rgb(255,255,255)";
+        }
 
         //var zindex = this.formatZ(this.getCSS(el,"zIndex"),cssPosition,parentStack.zIndex,el.parentNode);
 


### PR DESCRIPTION
Here's a few fixes and improvements we've made to get it working for BugHerd:

Depends on the linting and standards pull request (already merged into master): https://github.com/niklasvh/html2canvas/pull/100

Changes:
- Background color will be white if none or transparent was set
- Can now check origin from other windows using the new `windowHref` option
- Images will cache in memory

Usage for `windowHref` would look like this:

```
window.html2canvas(window.parent.document.body,{
          windowHref: window.parent.location.href,
         // ...
```
