### PR TITLE
ADDED - `scale` parameter to options

### DIFF
--- a/src/renderers/Canvas.js
+++ b/src/renderers/Canvas.js
@@ -97,12 +97,25 @@ _html2canvas.Renderer.Canvas = function( options ) {
             renderItem,
             testctx = ( hasCTX ) ? testCanvas.getContext("2d") : {},
             safeImages = [],
-            fstyle;
+            fstyle,
+            scaleX = 1,
+            scaleY = 1;
 
             canvas.width = canvas.style.width = (!usingFlashcanvas) ? options.width || zStack.ctx.width : Math.min(flashMaxSize, (options.width || zStack.ctx.width) );
             canvas.height = canvas.style.height = (!usingFlashcanvas) ? options.height || zStack.ctx.height : Math.min(flashMaxSize, (options.height || zStack.ctx.height) );
 
             fstyle = ctx.fillStyle;
+
+            if (options.scale) {
+                if (!isNaN(options.scale))
+                    scaleX = scaleY = options.scale;
+                else {
+                    scaleX = options.scale.x;
+                    scaleY = options.scale.y;
+                }
+                ctx.scale(scaleX, scaleY);
+            }
+
             ctx.fillStyle = zStack.backgroundColor;
             ctx.fillRect(0, 0, canvas.width, canvas.height);
             ctx.fillStyle = fstyle;
@@ -211,11 +224,11 @@ _html2canvas.Renderer.Canvas = function( options ) {
                     // crop image to the bounds of selected (single) element
                     bounds = _html2canvas.Util.Bounds( options.elements[ 0 ] );
                     newCanvas = doc.createElement('canvas');
-                    newCanvas.width = bounds.width;
-                    newCanvas.height = bounds.height;
-                    ctx = newCanvas.getContext("2d");
+                    newCanvas.width = bounds.width * scaleX;
+                    newCanvas.height = bounds.height * scaleY;
 
-                    ctx.drawImage( canvas, bounds.left, bounds.top, bounds.width, bounds.height, 0, 0, bounds.width, bounds.height );
+                    ctx = newCanvas.getContext("2d");
+                    ctx.drawImage( canvas, bounds.left * scaleX, bounds.top * scaleY, bounds.width * scaleX, bounds.height * scaleY, 0, 0, bounds.width * scaleX, bounds.height * scaleY );
                     canvas = null;
                     return newCanvas;
                 }


### PR DESCRIPTION
Hey there, 

I needed to make an image out of an element in my webapp and had to output an image that had a scaling factor applied to it.

I couldn't get any success with the `width` and `heigh`t properties so I added a `scale` parameter that can be passed as an option.

Scale can either be a number, or an object of the form `{ x : scaleX, y : scaleY }`. The resulting image should also be of good quality as the scaling factor is applied before the drawing.

Cheers,

Gabriel
