### PR TITLE
Added simple option to allow 'visibility:hidden' elements to be rendered

### DIFF
--- a/src/Parse.js
+++ b/src/Parse.js
@@ -1274,7 +1274,7 @@ _html2canvas.Parse = function ( images, options ) {
     function parseElement (el, stack) {
 
         // skip hidden elements and their children
-        if (getCSS(el, 'display') !== "none" && getCSS(el, 'visibility') !== "hidden") {
+        if (getCSS(el, 'display') !== "none" && getCSS(el, 'visibility') !== "hidden" || getCSS(el, 'display') !== "none" && options.renderHidden == true) {
 
             stack = renderElement(el, stack) || stack;
 

--- a/src/Util.js
+++ b/src/Util.js
@@ -28,6 +28,7 @@ html2canvas = function( elements, opts ) {
         ignoreElements: "IFRAME|OBJECT|PARAM",
         useOverflow: true,
         letterRendering: false,
+	renderHidden : false,
 
         // render options
 


### PR DESCRIPTION
There are a lot of times in my current project where I have the need to render an element that is not visible to the user.

I have added a simple option called 'renderHidden' which will allow all elements set to 'visibility:hidden' to be rendered.

A simple amendment but extremely useful to me.  And I should imagine for many others also.

P.S.  Fabulous work on this project nklasvh.  I'm really hoping to see some improved css transform support in the future (skew/translate etc) , these would be a great addition.
