### PR TITLE
Fixed parsing of generic INPUT elements on IE9

### DIFF
--- a/src/Parse.js
+++ b/src/Parse.js
@@ -1017,7 +1017,7 @@ _html2canvas.Parse = function (images, options) {
       case "INPUT":
         // TODO add all relevant type's, i.e. HTML5 new stuff
         // todo add support for placeholder attribute for browsers which support it
-        if (/^(text|url|email|submit|button|reset)$/.test(element.type) && (element.value || element.placeholder).length > 0){
+        if (/^(text|url|email|submit|button|reset)$/.test(element.type) && (element.value || element.placeholder || "").length > 0){
           renderFormValue(element, bounds, stack);
         }
         break;


### PR DESCRIPTION
Again, a trivial fix.
I stumbled over that while testing with IE9...
-Fritz
