### PR TITLE
added test for zIndex -1 element used as background

### DIFF
--- a/tests/cases/zindex/z-index4.html
+++ b/tests/cases/zindex/z-index4.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>z-index tests #4</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <script type="text/javascript" src="../../test.js"></script>
+    <style type="text/css">
+      div.lev1 {
+        width: 250px;
+        height: 70px;
+        position: relative;
+        border: 2px outset #669966;
+        background-color: #ccffcc;
+        padding-left: 5px;
+      }
+      div.background {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 250px;
+        background-color: #ffdddd;
+        z-index: -1;
+      }
+    </style></head>
+
+  <body>
+    <div class="lev1">
+      <span>LEVEL #1</span>
+    </div>
+    <div class="background"></div>
+    <div class="lev1">
+      <span>LEVEL #1</span>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
I added a (failing) test for an element that is used as background by setting it to position: absolute and z-index: -1; Such an element is used by WordPress (background of the admin menu) for example.

any ideas how to fix that?
