### PR TITLE
Solve Issue #163 to IE9

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -193,6 +193,9 @@ _html2canvas.Util.getCSS = function (el, attribute, index) {
     val = computedCSS[attribute];
 
     if (isBackgroundSizePosition) {
+        if(attribute.match( /^backgroundPosition$/ ) && el && el.currentStyle){
+            val = el.currentStyle[attribute] ? el.currentStyle[attribute] : val;
+        }
       val = (val || '').split( ',' );
       val = val[index || 0] || val[0] || 'auto';
       val = _html2canvas.Util.trimText(val).split(' ');


### PR DESCRIPTION
Solve Issue #163 to IE9

Aparently, IE9 has a problem with getComputedStyle function to the property backgroundPosition.
Fortunately, IE9 has an alternate property (currentStyle) with the "same" functionality that getComputedStyle.

I only add a hack to get currentStyle when is available instead getComputedStyle and check that currentStyle return a value (some times on IE10 this property not return nothing).
