### PR TITLE
Detecting support for getBoundingClientRect before execution.

### DIFF
--- a/src/Parse.js
+++ b/src/Parse.js
@@ -135,7 +135,7 @@ _html2canvas.Parse = function (images, options) {
     var range = doc.createRange();
     range.setStart(textNode, textOffset);
     range.setEnd(textNode, textOffset + text.length);
-    return range.getBoundingClientRect();
+    return range.getBoundingClientRect ? range.getBoundingClientRect() : null;
   }
 
   function textWrapperBounds(oldTextNode) {


### PR DESCRIPTION
This fixes an issue users were having when using html2canvas in production:

`Uncaught TypeError: Object #<Text> has no method 'getBoundingClientRect'`

Elsewhere H2C detects support for this method, this just adds consistency and coverage.
