### PR TITLE
Fix for "background-size: auto 100%"

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -337,6 +337,10 @@ function backgroundBoundsFactory( prop, el, bounds, image, imageIndex, backgroun
         topPos -= (backgroundSize || image).height * percentage;
       }
 
+      if(bgposition[0] === 'auto') {
+        left = topPos / image.height * image.width;
+      }
+
     } else {
       topPos = parseInt(bgposition[1],10);
     }


### PR DESCRIPTION
Currently background size auto 100% will set the background image's width to be the original width of the image, as opposed to scaling it properly by the height.
