### PR TITLE
incorect z-index sorting fixed

### DIFF
--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -39,7 +39,7 @@ _html2canvas.Renderer = function(parseQueue, options){
     })(parseQueue);
 
     function sortZ(context) {
-      Object.keys(context).sort().forEach(function(zi) {
+      Object.keys(context).sort(function(a, b) { return a - b; }).forEach(function(zi) {
         var nonPositioned = [],
         floated = [],
         positioned = [],


### PR DESCRIPTION
If you omit compare function in javascript `sort()` method it will sort  lexicographically (in dictionary order) according to the string conversion of each element. 

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Parameters

For example:

`[0, 9, 8, 10].sort()`

will place element with z-index `10` on 2nd position of the array
