### PR TITLE
Fix bug in WebKitGTK+, backgroundRepeat return "wrong" values

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -250,6 +250,13 @@ _html2canvas.Util.getCSS = function (element, attribute, index) {
     }
 
     var value = computedCSS[attribute];
+    if(attribute==="backgroundRepeat" && value.indexOf(" ")!==-1){
+        value = (
+            "no-repeat repeat"===value ? "repeat-y" : (
+                "repeat no-repeat"===value ? "repeat-x" : value
+            )
+        );
+    }
 
     if (/^background(Size|Position)$/.test(attribute)) {
         return parseBackgroundSizePosition(value, element, attribute, index);


### PR DESCRIPTION
In WebkitGTK+ (tested in version 1.2.0) `backgroundRepeat` property returns different values ​​in other engines.

eg.

> `background-repeat: repeat-x` returns as `repeat no-repeat`
> `background-repeat: repeat-y` returns as `no-repeat repeat`
