### PR TITLE
Fixed IndexSizeError in IE when the size of the image exceedes 8192 pixels

### DIFF
--- a/src/renderers/Canvas.js
+++ b/src/renderers/Canvas.js
@@ -115,7 +115,9 @@ _html2canvas.Renderer.Canvas = function(options) {
         newCanvas.height = Math.ceil(bounds.height);
         ctx = newCanvas.getContext("2d");
 
-        ctx.drawImage(canvas, bounds.left, bounds.top, bounds.width, bounds.height, 0, 0, bounds.width, bounds.height);
+		var imgData = canvas.getContext("2d").getImageData(bounds.left, bounds.top, bounds.width, bounds.height);
+		ctx.putImageData(imgData, 0, 0);
+
         canvas = null;
         return newCanvas;
       }


### PR DESCRIPTION
Patch for the IndexSizeError IN IE.
