### PR TITLE
bullet support for <li>

### DIFF
--- a/examples/lists.html
+++ b/examples/lists.html
@@ -13,12 +13,14 @@
 		<li style='list-style-type: lower-alpha'>OL Item (lower-alpha)</li>
 		<li style='list-style-type: upper-roman'>OL Item (upper-roman)</li>
 		<li style='list-style-type: lower-roman'>OL Item (lower-roman)</li>
+		<li style='list-style-type: none'>OL Item (none)</li>
 	</ol>
 	<ul>
 		<li>UL Item (default)</li>
 		<li style='list-style-type: circle'>UL Item (circle)</li>
 		<li style='list-style-type: square'>UL Item (square)</li>
 		<li style='list-style-type: disc'>UL Item (disc)</li>
+		<li style='list-style-type: none'>UL Item (none)</li>
 	</ul>
 
 	<h2>Not Implemented</h2>

--- a/examples/lists.html
+++ b/examples/lists.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
+<html>
+<head>
+<title>Lists Test</title>
+</head>
+<body>
+	<h1>Ordered And Unordered Lists</h1>
+	<h2>Implemented</h2>
+	<ol>
+		<li>OL Item (default)</li>
+		<li style='list-style-type: decimal'>OL Item (decimal)</li>
+		<li style='list-style-type: upper-alpha'>OL Item (upper-alpha)</li>
+		<li style='list-style-type: lower-alpha'>OL Item (lower-alpha)</li>
+		<li style='list-style-type: upper-roman'>OL Item (upper-roman)</li>
+		<li style='list-style-type: lower-roman'>OL Item (lower-roman)</li>
+	</ol>
+	<ul>
+		<li>UL Item (default)</li>
+		<li style='list-style-type: circle'>UL Item (circle)</li>
+		<li style='list-style-type: square'>UL Item (square)</li>
+		<li style='list-style-type: disc'>UL Item (disc)</li>
+	</ul>
+
+	<h2>Not Implemented</h2>
+	<pre>
+    upper-latin
+    lower-latin
+    armenian
+    cjk-ideographic
+    decimal-leading-zero
+    georgian  
+    hebrew
+    hiragana
+    hiragana-iroha
+    katakana
+    katakana-iroha
+        </pre>
+
+	<script type="text/javascript" src="../dist/html2canvas.js"></script>
+	<script type="text/javascript">
+        html2canvas(document.body).then(function(canvas) {
+            document.body.appendChild(canvas);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
I re-added elements from your previous implementation, plus added native context2d drawing for unordered lists.
http://rawgit.com/Flamenco/html2canvas/master/examples/lists.html

You might enjoy this, too:
http://rawgit.com/Flamenco/jsPDF/master/examples/html2pdf/lists.html

I have successfully bridged html2canvas code in order to generate a PDF instead of a canvas.  The nice thing about this is the PDFs can be scaled, selected, searched, and annotated (vs canvas).  Notice how much sharper the PDF is compared to the canvas implementation.

Here are your 2 demo files rendered to PDF format:
http://rawgit.com/Flamenco/jsPDF/master/examples/html2pdf/pdf.html
http://rawgit.com/Flamenco/jsPDF/master/examples/html2pdf/pdf2.html

You can view all examples here:
https://github.com/Flamenco/jsPDF/wiki/html2pdf

I needed to make a few modifications to the html2canvas code for signaling page breaks (page-break-before) to the canvas/context2d.  Please let me know if you are interesting in incorporating them and/or establishing an interface for pagination during the rendering process.

Thanks for your great work!
