### PR TITLE
Quick fix for proxy for v0.5

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -56,6 +56,8 @@ html2canvas.CanvasRenderer = CanvasRenderer;
 html2canvas.NodeContainer = NodeContainer;
 html2canvas.log = log;
 html2canvas.utils = utils;
+// Array to store proxy callbacks
+html2canvas.proxy = [];
 
 module.exports = (typeof(document) === "undefined" || typeof(Object.create) !== "function" || typeof(document.createElement("canvas").getContext) !== "function") ? function() {
     return Promise.reject("No canvas support");

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -20,11 +20,14 @@ function Proxy(src, proxyUrl, document) {
 var proxyCount = 0;
 
 function ProxyURL(src, proxyUrl, document) {
-    var supportsCORSImage = ('crossOrigin' in new Image());
+    // Disable CORS for now as it doesn't take options.useCORS in account
+    // And it defaults to true instead of false.
+    var supportsCORSImage = false; //('crossOrigin' in new Image());
     var callback = createCallback(supportsCORSImage);
     var url = createProxyUrl(proxyUrl, src, callback);
     return (supportsCORSImage ? Promise.resolve(url) : jsonp(document, url, callback).then(function(response) {
-        return "data:" + response.type + ";base64," + response.content;
+        // Proxy returns response with both type & content, return it directly.
+        return response;
     }));
 }
 


### PR DESCRIPTION
Proxy in v0.5 seems broken. I managed to load a cross-domain image by
doing those changes. html2canvas.proxy was not defined and the response
returned from the html2canvas PHP proxy was returning the result
including the data type.
