### PR TITLE
encode svg data into base64 to prevent some browsers to add html enti…

### DIFF
--- a/src/svgnodecontainer.js
+++ b/src/svgnodecontainer.js
@@ -10,7 +10,7 @@ function SVGNodeContainer(node, _native) {
         self.image = new Image();
         self.image.onload = resolve;
         self.image.onerror = reject;
-        self.image.src = "data:image/svg+xml," + (new XMLSerializer()).serializeToString(node);
+        self.image.src = "data:image/svg+xml;base64," + btoa((new XMLSerializer()).serializeToString(node));
         if (self.image.complete === true) {
             resolve(self.image);
         }


### PR DESCRIPTION
When we add the svg data to img.src, Firefox convert it to replace some characters with html entities and after it can load the image correctly !

Simple poc here : http://jsfiddle.net/3PfcC/

the solution is to convert svg into base64 string and ff can load it without error !

http://jsfiddle.net/0L6mrcqq/
