### PR TITLE
A better fix for #697: ignore text elements whose parents are svg

### DIFF
--- a/src/nodeparser.js
+++ b/src/nodeparser.js
@@ -794,7 +794,8 @@ function isPseudoElement(container) {
 }
 
 function isTextNode(container) {
-    return container.node.nodeType === Node.TEXT_NODE;
+	var parentElement = container.node.parentElement;
+    return container.node.nodeType === Node.TEXT_NODE && !(parentElement.ownerSVGElement || parentElement.tagName.toLowerCase() === "svg");
 }
 
 function zIndexSort(contexts) {


### PR DESCRIPTION
This code will detect whether a text node is within a SVG, no matter how
deep.
