### PR TITLE
not set logging options in window.html2canvas

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -16,8 +16,8 @@ function html2canvas(nodeList, options) {
     var index = html2canvasCloneIndex++;
     options = options || {};
     if (options.logging) {
-        window.html2canvas.logging = true;
-        window.html2canvas.start = Date.now();
+        log.enabled = true;
+        log.start = Date.now();
     }
 
     options.async = typeof(options.async) === "undefined" ? true : options.async;

--- a/src/log.js
+++ b/src/log.js
@@ -1,5 +1,6 @@
-module.exports = function() {
-    if (window.html2canvas.logging && window.console && window.console.log) {
-        Function.prototype.bind.call(window.console.log, (window.console)).apply(window.console, [(Date.now() - window.html2canvas.start) + "ms", "html2canvas:"].concat([].slice.call(arguments, 0)));
+function log() {
+    if (log.enabled && window.console && window.console.log) {
+        Function.prototype.bind.call(window.console.log, (window.console)).apply(window.console, [(Date.now() - log.start) + "ms", "html2canvas:"].concat([].slice.call(arguments, 0)));
     }
-};
+}
+module.exports = log;


### PR DESCRIPTION
window.html2canvas is undefined when used with RequireJS/AMD.
set in the log module instead.
fixes niklasvh/html2canvas#704.