### PR TITLE
no slip

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -100,7 +100,10 @@ function renderWindow(node, container, options, windowWidth, windowHeight) {
         } else if (node === clonedWindow.document.body || node === clonedWindow.document.documentElement || options.canvas != null) {
             canvas = renderer.canvas;
         } else {
-            canvas = crop(renderer.canvas, {width:  options.width != null ? options.width : bounds.width, height: options.height != null ? options.height : bounds.height, top: bounds.top, left: bounds.left, x: clonedWindow.pageXOffset, y: clonedWindow.pageYOffset});
+            var offset = utils.offsetBounds(node);
+            var x = Math.max(0, clonedWindow.pageXOffset - offset.left);
+            var y = Math.max(0, clonedWindow.pageYOffset - offset.top);
+            canvas = crop(renderer.canvas, {width:  options.width != null ? options.width : bounds.width, height: options.height != null ? options.height : bounds.height, top: bounds.top, left: bounds.left, x: x, y: y});
         }
 
         cleanupContainer(container, options);


### PR DESCRIPTION
About the issue #702, I made a patch to make captures not slipped even if window is scrolled and the capturing target is out of frame.
