### PR TITLE
Force SVGs to be loaded over the proxy, if configured

### DIFF
--- a/src/imageloader.js
+++ b/src/imageloader.js
@@ -60,11 +60,11 @@ ImageLoader.prototype.hasImageBackground = function(imageData) {
 ImageLoader.prototype.loadImage = function(imageData) {
     if (imageData.method === "url") {
         var src = imageData.args[0];
-        if (this.isSVG(src) && !this.support.svg && !this.options.allowTaint) {
+        if (this.isSVG(src) && !this.support.svg && !this.options.allowTaint && !this.options.proxy) {
             return new SVGContainer(src);
         } else if (src.match(/data:image\/.*;base64,/i)) {
             return new ImageContainer(src.replace(/url\(['"]{0,}|['"]{0,}\)$/ig, ''), false);
-        } else if (this.isSameOrigin(src) || this.options.allowTaint === true || this.isSVG(src)) {
+        } else if (this.isSameOrigin(src) || this.options.allowTaint === true || (this.isSVG(src) && !this.options.proxy)) {
             return new ImageContainer(src, false);
         } else if (this.support.cors && !this.options.allowTaint && this.options.useCORS) {
             return new ImageContainer(src, true);


### PR DESCRIPTION
SVG images would never be loaded via the proxy script and tainted the canvas, even when allowTaint was set to false and a proxy was configured.

I don't know WHY that was the case - however - this fixes the issue.
