### PR TITLE
fix(proxy): correctly determine supportsCORSImage

### DIFF
--- a/src/proxy.js
+++ b/src/proxy.js
@@ -19,7 +19,7 @@ function Proxy(src, proxyUrl, document) {
 var proxyCount = 0;
 
 function ProxyURL(src, proxyUrl, document) {
-    var supportsCORSImage = ('crossOrigin' in new Image());
+    var supportsCORSImage = (new Image()).crossOrigin;
     var callback = createCallback(supportsCORSImage);
     var url = createProxyUrl(proxyUrl, src, callback);
     return (supportsCORSImage ? Promise.resolve(url) : jsonp(document, url, callback).then(function(response) {


### PR DESCRIPTION
`crossOrigin` property of image objects can be `null` (which is the default value in FF and Chrome that I tested), and in this case `('crossOrigin' in new Image())` evaluates to true, which doesn't seems to be correct
