### PR TITLE
allow multiple font families

### DIFF
--- a/dist/html2canvas.js
+++ b/dist/html2canvas.js
@@ -3029,7 +3029,7 @@ CanvasRenderer.prototype.shape = function(shape) {
 };
 
 CanvasRenderer.prototype.font = function(color, style, variant, weight, size, family) {
-    this.setFillStyle(color).font = [style, variant, weight, size, family].join(" ").split(",")[0];
+    this.setFillStyle(color).font = [style, variant, weight, size].join(" ").split(",")[0] + ' ' + family;
 };
 
 CanvasRenderer.prototype.fontShadow = function(color, offsetX, offsetY, blur) {


### PR DESCRIPTION
Fix for #796 to allow multiple font families. The join/split was filtering out the other fonts.
