### PR TITLE
Show errors instead of silently suppressing them

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -27,6 +27,7 @@ function html2canvas(nodeList, options) {
     options.imageTimeout = typeof(options.imageTimeout) === "undefined" ? 10000 : options.imageTimeout;
     options.renderer = typeof(options.renderer) === "function" ? options.renderer : CanvasRenderer;
     options.strict = !!options.strict;
+    options.showErrors = !!options.showErrors;
 
     if (typeof(nodeList) === "string") {
         if (typeof(options.proxy) !== "string") {
@@ -47,6 +48,11 @@ function html2canvas(nodeList, options) {
             options.onrendered(canvas);
         }
         return canvas;
+    }).catch(function(e) {
+        if (options.showErrors) {
+            console.error(e.stack);
+        }
+        throw e;
     });
 }
 


### PR DESCRIPTION
The issue is when using some promises libraries (for example, jsPDF uses es6-promise library) an errors are silently suppressed. In this pull request I've added option `showErrors` with default `false`, but perhaps it is not needed and following would be enough:

```
}).catch(function(e) {
    console.error(e.stack);
    throw e;
});
```

I've tried to follow your code styling like naming error `e` instead of more proper `err` and did not put spaces around `!` instead of more proper `if ( ! options.showErrors )`.
