### PR TITLE
Add forceRenderAllText option to help support long strings or words

### DIFF
--- a/dist/html2canvas.js
+++ b/dist/html2canvas.js
@@ -2231,7 +2231,7 @@ NodeParser.prototype.paintFormValue = function(container) {
 NodeParser.prototype.paintText = function(container) {
     container.applyTextTransform();
     var characters = punycode.ucs2.decode(container.node.data);
-    var textList = (!this.options.letterRendering || noLetterSpacing(container)) && !hasUnicode(container.node.data) ? getWords(characters) : characters.map(function(character) {
+    var textList = !this.options.forceRenderAllText && (!this.options.letterRendering || noLetterSpacing(container)) && !hasUnicode(container.node.data) ? getWords(characters) : characters.map(function(character) {
         return punycode.ucs2.encode([character]);
     });
 


### PR DESCRIPTION
There are times where the code does not quite understand that when an HTML element has long strings or words without spaces and word wrap is set the text should wrap. It seems better not to try to count and size the letters from the HTML nodes in the Canvas element and allow an override when you know content will be very long. When this situation can occur it would be great to have an option to override the calculation and go straight to force the render. This pull request adds an option to force render all text.