### PR TITLE
Fix "Unable to copy canvas content" error when canvas has no 2d context

### DIFF
--- a/dist/html2canvas.js
+++ b/dist/html2canvas.js
@@ -530,17 +530,7 @@ function cloneCanvasContents(canvas, clonedCanvas) {
         if (clonedCanvas) {
             clonedCanvas.width = canvas.width;
             clonedCanvas.height = canvas.height;
-            const clonedCanvas2 = document.createElement('canvas');
-            if(!canvas.getContext('2d')){
-                clonedCanvas2.width = canvas.width;
-                clonedCanvas2.height = canvas.height;
-                clonedCanvas2.getContext("2d").drawImage(canvas,0,0);
-                clonedCanvas.getContext("2d").putImageData(clonedCanvas2.getContext("2d").getImageData(0, 0, canvas.width, canvas.height), 0, 0);
-
-            }
-            else{
-                clonedCanvas.getContext("2d").putImageData(canvas.getContext("2d").getImageData(0, 0, canvas.width, canvas.height), 0, 0);
-            }
+            clonedCanvas.getContext("2d").drawImage(canvas,0,0);
         }
     } catch(e) {
         log("Unable to copy canvas content from", canvas, e);

--- a/dist/html2canvas.js
+++ b/dist/html2canvas.js
@@ -530,7 +530,17 @@ function cloneCanvasContents(canvas, clonedCanvas) {
         if (clonedCanvas) {
             clonedCanvas.width = canvas.width;
             clonedCanvas.height = canvas.height;
-            clonedCanvas.getContext("2d").putImageData(canvas.getContext("2d").getImageData(0, 0, canvas.width, canvas.height), 0, 0);
+            const clonedCanvas2 = document.createElement('canvas');
+            if(!canvas.getContext('2d')){
+                clonedCanvas2.width = canvas.width;
+                clonedCanvas2.height = canvas.height;
+                clonedCanvas2.getContext("2d").drawImage(canvas,0,0);
+                clonedCanvas.getContext("2d").putImageData(clonedCanvas2.getContext("2d").getImageData(0, 0, canvas.width, canvas.height), 0, 0);
+
+            }
+            else{
+                clonedCanvas.getContext("2d").putImageData(canvas.getContext("2d").getImageData(0, 0, canvas.width, canvas.height), 0, 0);
+            }
         }
     } catch(e) {
         log("Unable to copy canvas content from", canvas, e);

--- a/src/clone.js
+++ b/src/clone.js
@@ -11,7 +11,17 @@ function cloneCanvasContents(canvas, clonedCanvas) {
         if (clonedCanvas) {
             clonedCanvas.width = canvas.width;
             clonedCanvas.height = canvas.height;
-            clonedCanvas.getContext("2d").putImageData(canvas.getContext("2d").getImageData(0, 0, canvas.width, canvas.height), 0, 0);
+            const clonedCanvas2 = document.createElement('canvas');
+            if(!canvas.getContext('2d')){
+                clonedCanvas2.width = canvas.width;
+                clonedCanvas2.height = canvas.height;
+                clonedCanvas2.getContext("2d").drawImage(canvas,0,0);
+                clonedCanvas.getContext("2d").putImageData(clonedCanvas2.getContext("2d").getImageData(0, 0, canvas.width, canvas.height), 0, 0);
+
+            }
+            else{
+                clonedCanvas.getContext("2d").putImageData(canvas.getContext("2d").getImageData(0, 0, canvas.width, canvas.height), 0, 0);
+            }
         }
     } catch(e) {
         log("Unable to copy canvas content from", canvas, e);

--- a/src/clone.js
+++ b/src/clone.js
@@ -11,17 +11,7 @@ function cloneCanvasContents(canvas, clonedCanvas) {
         if (clonedCanvas) {
             clonedCanvas.width = canvas.width;
             clonedCanvas.height = canvas.height;
-            const clonedCanvas2 = document.createElement('canvas');
-            if(!canvas.getContext('2d')){
-                clonedCanvas2.width = canvas.width;
-                clonedCanvas2.height = canvas.height;
-                clonedCanvas2.getContext("2d").drawImage(canvas,0,0);
-                clonedCanvas.getContext("2d").putImageData(clonedCanvas2.getContext("2d").getImageData(0, 0, canvas.width, canvas.height), 0, 0);
-
-            }
-            else{
-                clonedCanvas.getContext("2d").putImageData(canvas.getContext("2d").getImageData(0, 0, canvas.width, canvas.height), 0, 0);
-            }
+            clonedCanvas.getContext("2d").drawImage(canvas,0,0);
         }
     } catch(e) {
         log("Unable to copy canvas content from", canvas, e);


### PR DESCRIPTION
I was running into a lot of "Unable to copy canvas content" errors when using html2canvas on a web page containing, for example, a canvas with an experimental-webgl context.

`
canvas.getContext('experimental-webgl');
canvas.getContext('2d'); // now null
newCanvas.getContext('2d');
newCanvas.getContext('experimental-webgl'); // now null
`

This error can be fixed by cloning the canvas using: `clonedCanvas.getContext("2d").drawImage(canvas,0,0);`

Using getImageData is for pixel data access, not for copying canvases. Copying with it is very slow and hard on the browser. It should be avoided.

