### PR TITLE
SVGNodeContainer: base64 encoding is added in img.src

### DIFF
--- a/src/svgnodecontainer.js
+++ b/src/svgnodecontainer.js
@@ -9,7 +9,7 @@ function SVGNodeContainer(node, _native) {
         self.image = new Image();
         self.image.onload = resolve;
         self.image.onerror = reject;
-        self.image.src = "data:image/svg+xml," + (new XMLSerializer()).serializeToString(node);
+        self.image.src =  "data:image/svg+xml;base64," + window.btoa((new XMLSerializer()).serializeToString(node));
         if (self.image.complete === true) {
             resolve(self.image);
         }


### PR DESCRIPTION
For IE Edge, base64 encoding is required in SVG