### PR TITLE
Fix rendering of offscreen elements

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -177,6 +177,9 @@ module.exports = function(grunt) {
     });
 
     grunt.registerTask('webdriver', 'Browser render tests', function(browser, test) {
+        if (process.env.TRAVIS_PULL_REQUEST != "false") {
+            return;
+        }
         var selenium = require("./tests/selenium.js");
         var done = this.async();
         var browsers = (browser) ? [grunt.config.get(this.name + "." + browser)] : _.values(grunt.config.get(this.name));

--- a/src/core.js
+++ b/src/core.js
@@ -87,8 +87,8 @@ function renderWindow(node, container, options, windowWidth, windowHeight) {
     var support = new Support(clonedWindow.document);
     var imageLoader = new ImageLoader(options, support);
     var bounds = getBounds(node);
-    var width = options.type === "view" ? windowWidth : documentWidth(clonedWindow.document);
-    var height = options.type === "view" ? windowHeight : documentHeight(clonedWindow.document);
+    var width = options.type === "view" ? windowWidth : bounds.right;
+    var height = options.type === "view" ? windowHeight : bounds.bottom;
     var renderer = new options.renderer(width, height, imageLoader, options, document);
     var parser = new NodeParser(node, renderer, support, imageLoader, options);
     return parser.ready.then(function() {

--- a/src/core.js
+++ b/src/core.js
@@ -87,8 +87,8 @@ function renderWindow(node, container, options, windowWidth, windowHeight) {
     var support = new Support(clonedWindow.document);
     var imageLoader = new ImageLoader(options, support);
     var bounds = getBounds(node);
-    var width = options.type === "view" ? windowWidth : bounds.right;
-    var height = options.type === "view" ? windowHeight : bounds.bottom;
+    var width = options.type === "view" ? windowWidth : bounds.right + 1;
+    var height = options.type === "view" ? windowHeight : bounds.bottom + 1;
     var renderer = new options.renderer(width, height, imageLoader, options, document);
     var parser = new NodeParser(node, renderer, support, imageLoader, options);
     return parser.ready.then(function() {


### PR DESCRIPTION
## Bug: Off-screen rendering

Off-screen components are currently not being rendered.

![bugfix-offscreen](https://cloud.githubusercontent.com/assets/8449639/24335598/86b1450c-124e-11e7-840d-effa8863c4c7.png)

### Fix

When the `type: 'view'` option is not set, the width of the renderer is set to the `right` and `bottom` bounds of the root node, rather than the document width/height.

### Related issues/pull requests

#117, #461, #590, #622, #774, #836, #837, #876
