### PR TITLE
Add box-shadow rendering

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -177,6 +177,9 @@ module.exports = function(grunt) {
     });
 
     grunt.registerTask('webdriver', 'Browser render tests', function(browser, test) {
+        if (process.env.TRAVIS_PULL_REQUEST != "false") {
+            return;
+        }
         var selenium = require("./tests/selenium.js");
         var done = this.async();
         var browsers = (browser) ? [grunt.config.get(this.name + "." + browser)] : _.values(grunt.config.get(this.name));

--- a/src/nodeparser.js
+++ b/src/nodeparser.js
@@ -332,7 +332,7 @@ NodeParser.prototype.paintElement = function(container) {
 
     this.renderer.mask(container.backgroundClip, function() {
         this.renderer.renderShadows(container, container.borders.clip);
-    }, this);
+    }, this, container);
 
     this.renderer.clip(container.clip, function() {
         this.renderer.renderBorders(container.borders.borders);

--- a/src/nodeparser.js
+++ b/src/nodeparser.js
@@ -331,7 +331,7 @@ NodeParser.prototype.paintElement = function(container) {
     }, this);
 
     this.renderer.mask(container.backgroundClip, function() {
-        this.renderer.renderShadows(container, bounds);
+        this.renderer.renderShadows(container, container.borders.clip);
     }, this);
 
     this.renderer.clip(container.clip, function() {

--- a/src/nodeparser.js
+++ b/src/nodeparser.js
@@ -330,7 +330,7 @@ NodeParser.prototype.paintElement = function(container) {
         this.renderer.renderBackground(container, bounds, container.borders.borders.map(getWidth));
     }, this);
 
-    this.renderer.mask(bounds, function() {
+    this.renderer.mask(container.backgroundClip, function() {
         this.renderer.renderShadows(container, bounds);
     }, this);
 

--- a/src/nodeparser.js
+++ b/src/nodeparser.js
@@ -330,6 +330,10 @@ NodeParser.prototype.paintElement = function(container) {
         this.renderer.renderBackground(container, bounds, container.borders.borders.map(getWidth));
     }, this);
 
+    this.renderer.mask(bounds, function() {
+        this.renderer.renderShadows(container, bounds);
+    }, this);
+
     this.renderer.clip(container.clip, function() {
         this.renderer.renderBorders(container.borders.borders);
     }, this);

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -44,6 +44,14 @@ Renderer.prototype.renderBackgroundColor = function(container, bounds) {
     }
 };
 
+Renderer.prototype.renderShadows = function(container, bounds) {
+    var boxShadow = container.css('boxShadow');
+    if (boxShadow !== 'none') {
+        var shadows = boxShadow.split(/,(?![^(]*\))/);
+        this.shadow(bounds.left, bounds.top, bounds.width, bounds.height, shadows);
+    }
+};
+
 Renderer.prototype.renderBorders = function(borders) {
     borders.forEach(this.renderBorder, this);
 };

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -44,11 +44,11 @@ Renderer.prototype.renderBackgroundColor = function(container, bounds) {
     }
 };
 
-Renderer.prototype.renderShadows = function(container, bounds) {
+Renderer.prototype.renderShadows = function(container, shape) {
     var boxShadow = container.css('boxShadow');
     if (boxShadow !== 'none') {
         var shadows = boxShadow.split(/,(?![^(]*\))/);
-        this.shadow(bounds.left, bounds.top, bounds.width, bounds.height, shadows);
+        this.shadow(shape, shadows);
     }
 };
 

--- a/src/renderers/canvas.js
+++ b/src/renderers/canvas.js
@@ -108,14 +108,14 @@ CanvasRenderer.prototype.clip = function(shapes, callback, context) {
     this.ctx.restore();
 };
 
-CanvasRenderer.prototype.mask = function(shapes, callback, context) {
+CanvasRenderer.prototype.mask = function(shapes, callback, context, container) {
     var borderClip = shapes[shapes.length-1];
     if (borderClip && borderClip.length) {
         var canvasBorderCCW = ["rect", this.canvas.width, 0, -this.canvas.width, this.canvas.height];
         var maskShape = [canvasBorderCCW].concat(borderClip).concat([borderClip[0]]);
         shapes = shapes.slice(0,-1).concat([maskShape]);
     }
-    this.clip(shapes, callback, context);
+    this.clip(shapes, callback, context, container);
 };
 
 CanvasRenderer.prototype.shape = function(shape) {

--- a/src/renderers/canvas.js
+++ b/src/renderers/canvas.js
@@ -109,14 +109,14 @@ CanvasRenderer.prototype.clip = function(shapes, callback, context) {
     this.ctx.restore();
 };
 
-CanvasRenderer.prototype.mask = function(bounds, callback, context) {
-    var canvasBorderCCW = ["rect", this.canvas.width, 0, -this.canvas.width, this.canvas.height];
-    var boundsCW = ["rect", bounds.left, bounds.top, bounds.width, bounds.height];
-    this.ctx.save();
-    var shape = [canvasBorderCCW, boundsCW];
-    this.shape(shape).clip();
-    callback.call(context);
-    this.ctx.restore();
+CanvasRenderer.prototype.mask = function(shapes, callback, context) {
+    var borderClip = shapes[shapes.length-1];
+    if (borderClip && borderClip.length) {
+        var canvasBorderCCW = ["rect", this.canvas.width, 0, -this.canvas.width, this.canvas.height];
+        var maskShape = [canvasBorderCCW].concat(borderClip).concat([borderClip[0]]);
+        shapes = shapes.slice(0,-1).concat([maskShape]);
+    }
+    this.clip(shapes, callback, context);
 };
 
 CanvasRenderer.prototype.shape = function(shape) {

--- a/src/renderers/canvas.js
+++ b/src/renderers/canvas.js
@@ -41,6 +41,39 @@ CanvasRenderer.prototype.circleStroke = function(left, top, size, color, stroke,
     this.ctx.stroke();
 };
 
+CanvasRenderer.prototype.shadow = function(left, top, width, height, shadows) {
+    var parseShadow = function(str) {
+        var propertyFilters = { color: /^(#|rgb|hsl|(?!(inset|initial|inherit))\D+)/i, inset: /^inset/i, px: /px$/i };
+        var pxPropertyNames = [ 'x', 'y', 'blur', 'spread' ];
+        var properties = str.split(/ (?![^(]*\))/);
+        var info = {};
+        for (var key in propertyFilters) {
+            info[key] = properties.filter(propertyFilters[key].test.bind(propertyFilters[key]));
+            info[key] = info[key].length === 0 ? null : info[key].length === 1 ? info[key][0] : info[key];
+        }
+        for (var i=0; i<info.px.length; i++) {
+            info[pxPropertyNames[i]] = parseInt(info.px[i]);
+        }
+        return info;
+    };
+    var drawShadow = function(shadow) {
+        var info = parseShadow(shadow);
+        if (!info.inset) {
+            context.shadowOffsetX = info.x;
+            context.shadowOffsetY = info.y;
+            context.shadowColor = info.color;
+            context.shadowBlur = info.blur;
+            context.fill();
+        }
+    };
+    var context = this.setFillStyle('white');
+    context.save();
+    context.beginPath();
+    context.rect(left, top, width, height);
+    shadows.forEach(drawShadow, this);
+    context.restore();
+};
+
 CanvasRenderer.prototype.drawShape = function(shape, color) {
     this.shape(shape);
     this.setFillStyle(color).fill();
@@ -72,6 +105,16 @@ CanvasRenderer.prototype.clip = function(shapes, callback, context) {
     shapes.filter(hasEntries).forEach(function(shape) {
         this.shape(shape).clip();
     }, this);
+    callback.call(context);
+    this.ctx.restore();
+};
+
+CanvasRenderer.prototype.mask = function(bounds, callback, context) {
+    var canvasBorderCCW = ["rect", this.canvas.width, 0, -this.canvas.width, this.canvas.height];
+    var boundsCW = ["rect", bounds.left, bounds.top, bounds.width, bounds.height];
+    this.ctx.save();
+    var shape = [canvasBorderCCW, boundsCW];
+    this.shape(shape).clip();
     callback.call(context);
     this.ctx.restore();
 };

--- a/src/renderers/canvas.js
+++ b/src/renderers/canvas.js
@@ -41,7 +41,7 @@ CanvasRenderer.prototype.circleStroke = function(left, top, size, color, stroke,
     this.ctx.stroke();
 };
 
-CanvasRenderer.prototype.shadow = function(left, top, width, height, shadows) {
+CanvasRenderer.prototype.shadow = function(shape, shadows) {
     var parseShadow = function(str) {
         var propertyFilters = { color: /^(#|rgb|hsl|(?!(inset|initial|inherit))\D+)/i, inset: /^inset/i, px: /px$/i };
         var pxPropertyNames = [ 'x', 'y', 'blur', 'spread' ];
@@ -68,8 +68,7 @@ CanvasRenderer.prototype.shadow = function(left, top, width, height, shadows) {
     };
     var context = this.setFillStyle('white');
     context.save();
-    context.beginPath();
-    context.rect(left, top, width, height);
+    this.shape(shape);
     shadows.forEach(drawShadow, this);
     context.restore();
 };


### PR DESCRIPTION
## Feature: Box-shadows

You know 'em, you love 'em: `box-shadow`s! Requests for this feature date back to May 2013.

![feature-box-shadow](https://cloud.githubusercontent.com/assets/8449639/24335780/b7e9ac2e-1251-11e7-862e-a99702ca8443.png)

### Implementation

In `paintElement`, after rendering backgrounds but before borders, there is now `renderShadows`. It uses a new `.mask()` tool which behaves the opposite of `.clip()`, meaning the shadow will be drawn only outside the element container.

This feature includes support of multiple `box-shadow`s.

### Related issues/pull requests

#220, #221, #246, #510, #597, #673, #763
