### PR TITLE
Remove grunt webdriver task for pull requests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -177,6 +177,9 @@ module.exports = function(grunt) {
     });
 
     grunt.registerTask('webdriver', 'Browser render tests', function(browser, test) {
+        if (process.env.TRAVIS_PULL_REQUEST != "false") {
+            return;
+        }
         var selenium = require("./tests/selenium.js");
         var done = this.async();
         var browsers = (browser) ? [grunt.config.get(this.name + "." + browser)] : _.values(grunt.config.get(this.name));


### PR DESCRIPTION
## Bug: Grunt webdriver task for pull requests

The `webdriver` task in the Grunt testing process doesn't work for external pull requests, and is causing all PRs to fail.

### Fix

The webdriver task is set up to connect to [Sauce Labs](https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-Sauce-Labs), which hosts the Selenium cloud for browser testing. To connect to Sauce Labs, `tests/utils.js` looks for the environment variables `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY`.

Unfortunately, those variables are [encrypted in .travis.yml](https://docs.travis-ci.com/user/environment-variables/#Defining-encrypted-variables-in-.travis.yml) (as they should be), which means that they are *not available to pull requests from forks*. Thus the test fails, because it never connects to Sauce Labs.

To prevent this guaranteed failure, I have disabled the `webdriver` task if it detects that it is being performed in a pull request, as recommended in the [Travis documentation](https://docs.travis-ci.com/user/pull-requests/#Pull-Requests-and-Security-Restrictions):

> To work around this, restrict these tests only to situations where the environment variables are available, or disable them for pull requests entirely.

### Related issues/pull requests

#782, #941, #1084, #1085, #1086, #1087, #1088

(And really every open pull request, since none can currently pass with the current setup).
