### PR TITLE
Markdown requires a space after the hashtags

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ html2canvas
  The script allows you to take "screenshots" of webpages or parts of it, directly on the users browser. The screenshot is based on the DOM and as such may not be 100% accurate to the real representation as it does not make an actual screenshot, but builds the screenshot based on the information available on the page.
 
 
-###How does it work?###
+### How does it work?###
 The script renders the current page as a canvas image, by reading the DOM and the different styles applied to the elements.
 
 It does **not require any rendering from the server**, as the whole image is created on the **clients browser**. However, as it is heavily dependent on the browser, this library is *not suitable* to be used in nodejs.
@@ -18,7 +18,7 @@ It doesn't magically circumvent any browser content policy restrictions either, 
 
 The script is still in a **very experimental state**, so I don't recommend using it in a production environment nor start building applications with it yet, as there will be still major changes made.
 
-###Browser compatibility###
+### Browser compatibility###
 
 The library should work fine on the following browsers (with `Promise` polyfill):
 


### PR DESCRIPTION
If this space is missing, the markdown may get wrongly rendered on platforms like github