### PR TITLE
Add support for dotted/dashed border styles

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -177,6 +177,9 @@ module.exports = function(grunt) {
     });
 
     grunt.registerTask('webdriver', 'Browser render tests', function(browser, test) {
+        if (process.env.TRAVIS_PULL_REQUEST != "false") {
+            return;
+        }
         var selenium = require("./tests/selenium.js");
         var done = this.async();
         var browsers = (browser) ? [grunt.config.get(this.name + "." + browser)] : _.values(grunt.config.get(this.name));

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -50,7 +50,16 @@ Renderer.prototype.renderBorders = function(borders) {
 
 Renderer.prototype.renderBorder = function(data) {
     if (!data.color.isTransparent() && data.args !== null) {
-        this.drawShape(data.args, data.color);
+        if (data.style === 'dashed' || data.style === 'dotted') {
+            var dash = (data.style === 'dashed') ? 3 : data.width;
+            this.ctx.setLineDash([dash]);
+            this.path(data.pathArgs);
+            this.ctx.strokeStyle = data.color;
+            this.ctx.lineWidth = data.width;
+            this.ctx.stroke();
+        } else {
+            this.drawShape(data.args, data.color);
+        }
     }
 };
 

--- a/src/renderers/canvas.js
+++ b/src/renderers/canvas.js
@@ -89,6 +89,18 @@ CanvasRenderer.prototype.shape = function(shape) {
     return this.ctx;
 };
 
+CanvasRenderer.prototype.path = function(shape) {
+    this.ctx.beginPath();
+    shape.forEach(function(point, index) {
+        if (point[0] === "rect") {
+            this.ctx.rect.apply(this.ctx, point.slice(1));
+        } else {
+            this.ctx[(index === 0) ? "moveTo" : point[0] + "To" ].apply(this.ctx, point.slice(1));
+        }
+    }, this);
+    return this.ctx;
+};
+
 CanvasRenderer.prototype.font = function(color, style, variant, weight, size, family) {
     this.setFillStyle(color).font = [style, variant, weight, size, family].join(" ").split(",")[0];
 };


### PR DESCRIPTION
## Feature: Dotted/dashed border styles

Until now, dotted/dashed borders were rendered as solid borders. This should now render them correctly.

### Implementation

The default border-rendering is left untouched: it is rendered as a shape and filled with a solid color.

However, when a border is detected as 'dotted' or 'dashed', rendering now switches to a path-based approach, which draws the path of the border and applies the appropriate style using `ctx.setLineDash()`.

Thanks to @Rodris in #210 for getting things started.

### Related issues/pull requests

#96, #210, #366, #413, #414, #589, #984, #1036, #1117
