### PR TITLE
Bugfix: Fix underlines

### DIFF
--- a/src/renderer/CanvasRenderer.js
+++ b/src/renderer/CanvasRenderer.js
@@ -212,7 +212,7 @@ export default class CanvasRenderer implements RenderTarget<HTMLCanvasElement> {
                             const {baseline} = this.options.fontMetrics.getMetrics(font);
                             this.rectangle(
                                 text.bounds.left,
-                                Math.round(text.bounds.top + baseline),
+                                Math.round(text.bounds.top + text.bounds.height - baseline),
                                 text.bounds.width,
                                 1,
                                 textDecorationColor


### PR DESCRIPTION
Fix underline positioning.

Since `ctx.textBaseline` is set to 'bottom', underlines need to be positioned relative to the bottom of the text, not the top.