### PR TITLE
Bugfix: Fix parseLetterSpacing for decimal values

### DIFF
--- a/src/parsing/letterSpacing.js
+++ b/src/parsing/letterSpacing.js
@@ -5,6 +5,6 @@ export const parseLetterSpacing = (letterSpacing: string): number => {
     if (letterSpacing === 'normal') {
         return 0;
     }
-    const value = parseInt(letterSpacing, 10);
+    const value = parseFloat(letterSpacing, 10);
     return isNaN(value) ? 0 : value;
 };


### PR DESCRIPTION
parseLetterSpacing was returning zero for decimal values less than 1.

This was causing TextBounds to not use letterRendering on elements with non-zero letter-spacing.