### PR TITLE
Added support for gradient background size and fixed linear gradient angle when vendor prefix is used

### DIFF
--- a/src/Gradient.js
+++ b/src/Gradient.js
@@ -34,7 +34,7 @@ export const parseGradient = (
     bounds: Bounds
 ): ?Gradient => {
     if (method === 'linear-gradient') {
-        return parseLinearGradient(args, bounds);
+        return parseLinearGradient(args, bounds, !!prefix);
     } else if (method === 'gradient' && args[0] === 'linear') {
         // TODO handle correct angle
         return parseLinearGradient(
@@ -46,18 +46,23 @@ export const parseGradient = (
                     // $FlowFixMe
                     .map(v => v[2])
             ),
-            bounds
+            bounds,
+            !!prefix
         );
     }
 };
 
-const parseLinearGradient = (args: Array<string>, bounds: Bounds): Gradient => {
+const parseLinearGradient = (args: Array<string>, bounds: Bounds, hasPrefix: boolean): Gradient => {
     const angle = parseAngle(args[0]);
     const HAS_SIDE_OR_CORNER = SIDE_OR_CORNER.test(args[0]);
     const HAS_DIRECTION = HAS_SIDE_OR_CORNER || angle !== null || PERCENTAGE_ANGLES.test(args[0]);
     const direction = HAS_DIRECTION
         ? angle !== null
-          ? calculateGradientDirection(angle, bounds)
+          ? calculateGradientDirection(
+                // if there is a prefix, the 0° angle points due East (instead of North per W3C)
+                hasPrefix ? angle - Math.PI * 0.5 : angle,
+                bounds
+            )
           : HAS_SIDE_OR_CORNER
             ? parseSideOrCorner(args[0], bounds)
             : parsePercentageAngle(args[0], bounds)

--- a/src/parsing/background.js
+++ b/src/parsing/background.js
@@ -123,6 +123,19 @@ export const calculateBackgroundSize = (
     return new Size(width, height);
 };
 
+export const calculateGradientBackgroundSize = (
+    backgroundImage: BackgroundImage,
+    bounds: Bounds
+): Size => {
+    const size = backgroundImage.size;
+    const width = size[0].value ? size[0].value.getAbsoluteValue(bounds.width) : bounds.width;
+    const height = size[1].value
+        ? size[1].value.getAbsoluteValue(bounds.height)
+        : size[0].value ? width : bounds.height;
+
+    return new Size(width, height);
+};
+
 const AUTO_SIZE = new BackgroundSize(AUTO);
 
 export const calculateBackgroungPaintingArea = (

--- a/tests/reftests/background/linear-gradient2.html
+++ b/tests/reftests/background/linear-gradient2.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html>
+	<head>
+		<title>Background attribute tests</title>
+		<script type="text/javascript" src="../../test.js"></script>
+
+		<style>
+			body {
+				background-color: blanchedalmond;
+			}
+
+			div {
+				display: inline-block;
+				width: 100px;
+				height: 100px;
+				padding: 10px;
+				border: 15px solid black;
+			}
+		</style>
+	</head>
+	<body>
+		<div style="background: -webkit-linear-gradient(90deg, blue, red);"></div>
+		<div style="background: linear-gradient(90deg, blue, red);"></div>
+		<div style="background: linear-gradient(45deg, blue, red);"></div>
+		<div style="background: linear-gradient(45deg, blue, red); width:200px;"></div>
+		<div style="background-image: linear-gradient(45deg, blue, red); background-position: 20px 30px; background-size: 60px; background-repeat: no-repeat"></div>
+		<div style="background-image: linear-gradient(45deg, blue, red); background-position: 20px 30px; background-size: 60px;"></div>
+		<div style="background-image: linear-gradient(45deg, blue, red);padding:0"></div>
+		<div style="background: linear-gradient(red, red 60%, blue);"></div>
+		<div style="background: linear-gradient(90deg, red 60%, blue);"></div>
+		<div style="background: linear-gradient(135deg, red, red 60%, blue);"></div>
+		<div style="background: linear-gradient(to right, red, red 60%, blue);"></div>
+		<div style="background: linear-gradient(to right, red, orange, yellow, green, blue, indigo, violet);"></div>
+		<div style="background: linear-gradient(60deg, yellow 0%, orange 10%, red 50%, blue 90%, cyan 100%);"></div>
+		<div style="background: linear-gradient(45deg, yellow 0%, orange 10%, red 50%, blue 90%, cyan 100%); background-origin: content-box"></div>
+		<div style="background: linear-gradient(90deg, yellow 0%, orange 10%, red 50%, blue 90%, cyan 100%); background-origin: padding-box"></div>
+		<div style="background: linear-gradient(90deg, yellow 0%, orange 10%, red 50%, blue 90%, cyan 100%); background-origin: border-box"></div>
+		<div style="background: linear-gradient(to right, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 100%); "></div>
+		<div style="background: linear-gradient(90deg, yellow 0%, orange 10%, red 50%, blue 90%, cyan 100%) content-box;"></div>
+		<div style="background: linear-gradient(60deg, hsla(120,80%,50%,0.8) 0%, transparent 50%, rgba(255,100,100,0.5) 100%);"></div>
+	</body>
+</html>


### PR DESCRIPTION
**Summary**

Added support for gradient background size (respecting background-size and background-origin), and fixed linear gradient angle when vendor prefix is used (the 0° angle then points due East, in the finalized W3C specification, it points due North).

Repeating gradients are not yet supported.

This PR fixes/implements the following **bugs/features**

* [x] Bug: corrected the angle direction when using vendor prefixes
* [x] Feature: support for background-size and background-origin

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Better support for linear gradient backgrounds.

**Test plan (required)**

Added tests/reftests/background/linear-gradient2.html

