### PR TITLE
Fixes #1363 - remove console.log on library init and use the Logger

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,12 +32,6 @@ export type Options = {
 };
 
 const html2canvas = (element: HTMLElement, conf: ?Options): Promise<*> => {
-    // eslint-disable-next-line no-console
-    if (typeof console === 'object' && typeof console.log === 'function') {
-        // eslint-disable-next-line no-console
-        console.log(`html2canvas ${__VERSION__}`);
-    }
-
     const config = conf || {};
     const logger = new Logger(typeof config.logging === 'boolean' ? config.logging : true);
 
@@ -51,6 +45,9 @@ const html2canvas = (element: HTMLElement, conf: ?Options): Promise<*> => {
     if (!ownerDocument) {
         return Promise.reject(`Provided element is not within a Document`);
     }
+
+    logger.log(`html2canvas ${__VERSION__}`);
+
     const defaultView = ownerDocument.defaultView;
 
     const scrollX = defaultView.pageXOffset;


### PR DESCRIPTION
**Summary**

This PR fixes #1363 - the console.log during initialization of the library was removed - I believe that the user of html2canvas should be able to switch off logging completely.


Fixes #1363 
