### PR TITLE
feat(#1386): added the ability to filter by class names

### DIFF
--- a/src/Clone.js
+++ b/src/Clone.js
@@ -203,7 +203,8 @@ export class DocumentCloner {
                             windowWidth: documentElement.ownerDocument.defaultView.innerWidth,
                             windowHeight: documentElement.ownerDocument.defaultView.innerHeight,
                             scrollX: documentElement.ownerDocument.defaultView.pageXOffset,
-                            scrollY: documentElement.ownerDocument.defaultView.pageYOffset
+                            scrollY: documentElement.ownerDocument.defaultView.pageYOffset,
+                            classesToIgnore: this.options.classesToIgnore
                         },
                         this.logger.child(iframeKey)
                     );
@@ -268,8 +269,11 @@ export class DocumentCloner {
         for (let child = node.firstChild; child; child = child.nextSibling) {
             if (
                 child.nodeType !== Node.ELEMENT_NODE ||
-                // $FlowFixMe
-                (child.nodeName !== 'SCRIPT' && !child.hasAttribute(IGNORE_ATTRIBUTE))
+                (child.nodeName !== 'SCRIPT' &&
+                    // $FlowFixMe
+                    !child.hasAttribute(IGNORE_ATTRIBUTE) &&
+                    // $FlowFixMe
+                    !this.options.classesToIgnore.some(cls => child.classList.contains(cls)))
             ) {
                 if (!this.copyStyles || child.nodeName !== 'STYLE') {
                     clone.appendChild(this.cloneNode(child));

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,8 @@ export type Options = {
     scrollX: number,
     scrollY: number,
     windowWidth: number,
-    windowHeight: number
+    windowHeight: number,
+    classesToIgnore: Array<string>
 };
 
 const html2canvas = (element: HTMLElement, conf: ?Options): Promise<*> => {
@@ -81,7 +82,8 @@ const html2canvas = (element: HTMLElement, conf: ?Options): Promise<*> => {
         windowWidth: defaultView.innerWidth,
         windowHeight: defaultView.innerHeight,
         scrollX: defaultView.pageXOffset,
-        scrollY: defaultView.pageYOffset
+        scrollY: defaultView.pageYOffset,
+        classesToIgnore: []
     };
 
     const result = renderElement(element, {...defaultOptions, ...config}, logger);


### PR DESCRIPTION
We can add the classesToIgnore property to options to filter elements.

Example for google maps:
`html2canvas(document.getElementById('map'), {
useCORS: true, classesToIgnore: ['gmnoprint'] });
`

https://github.com/niklasvh/html2canvas/issues/1386