### PR TITLE
Bugfix for underline position and console log

### DIFF
--- a/src/Logger.js
+++ b/src/Logger.js
@@ -18,11 +18,13 @@ export default class Logger {
 
     // eslint-disable-next-line flowtype/no-weak-types
     log(...args: any) {
-        if (this.enabled && window.console && window.console.log) {
+        // eslint-disable-next-line no-console
+        if (this.enabled && typeof console !== undefined && console.log) {
             Function.prototype.bind
-                .call(window.console.log, window.console)
+                // eslint-disable-next-line no-console
+                .call(console.log, console)
                 .apply(
-                    window.console,
+                    console,
                     [
                         Date.now() - this.start + 'ms',
                         this.id ? `html2canvas (${this.id}):` : 'html2canvas:'
@@ -33,11 +35,11 @@ export default class Logger {
 
     // eslint-disable-next-line flowtype/no-weak-types
     error(...args: any) {
-        if (this.enabled && window.console && window.console.error) {
+        if (this.enabled && console && console.error) {
             Function.prototype.bind
-                .call(window.console.error, window.console)
+                .call(console.error, console)
                 .apply(
-                    window.console,
+                    console,
                     [
                         Date.now() - this.start + 'ms',
                         this.id ? `html2canvas (${this.id}):` : 'html2canvas:'

--- a/src/index.js
+++ b/src/index.js
@@ -32,14 +32,10 @@ export type Options = {
 };
 
 const html2canvas = (element: HTMLElement, conf: ?Options): Promise<*> => {
-    // eslint-disable-next-line no-console
-    if (typeof console === 'object' && typeof console.log === 'function') {
-        // eslint-disable-next-line no-console
-        console.log(`html2canvas ${__VERSION__}`);
-    }
-
     const config = conf || {};
     const logger = new Logger(typeof config.logging === 'boolean' ? config.logging : true);
+
+    logger.log(`html2canvas ${__VERSION__}`);
 
     if (__DEV__ && typeof config.onrendered === 'function') {
         logger.error(

--- a/src/renderer/CanvasRenderer.js
+++ b/src/renderer/CanvasRenderer.js
@@ -250,7 +250,7 @@ export default class CanvasRenderer implements RenderTarget<HTMLCanvasElement> {
                             const {baseline} = this.options.fontMetrics.getMetrics(font);
                             this.rectangle(
                                 text.bounds.left,
-                                Math.round(text.bounds.top + text.bounds.height - baseline),
+                                Math.round(text.bounds.top + baseline),
                                 text.bounds.width,
                                 1,
                                 textDecorationColor


### PR DESCRIPTION
I've removed unnecessary console log that logs version (even incorrectly) at runtime and fixed position of link underline. The latter can be reproduced in examples/demo2.html

I've changed logger a bit as well, so that it would use console directly and not via window. Tests did not pass otherwise and complained that window is undefined.

Fixes for #1364 and #1363 
