### PR TITLE
IE11 Member not found fix Wrap accesing the cssText property in a try...catch

### DIFF
--- a/src/Clone.js
+++ b/src/Clone.js
@@ -230,19 +230,17 @@ export class DocumentCloner {
         }
 
         if (node instanceof HTMLStyleElement && node.sheet && node.sheet.cssRules) {
-            const css = [].slice
-                .call(node.sheet.cssRules, 0)
-                .reduce((css, rule) => {
-                    try {
-                        if (rule && rule.cssText) {
-                          return css + rule.cssText;
-                        }
-                        return css;
-                      } catch (err) {
-                        this.logger.log('Unable to access cssText property', rule.name);
-                        return css;
-                      }
-                });
+            const css = [].slice.call(node.sheet.cssRules, 0).reduce((css, rule) => {
+                try {
+                    if (rule && rule.cssText) {
+                        return css + rule.cssText;
+                    }
+                    return css;
+                } catch (err) {
+                    this.logger.log('Unable to access cssText property', rule.name);
+                    return css;
+                }
+            });
             const style = node.cloneNode(false);
             style.textContent = css;
             return style;

--- a/src/Clone.js
+++ b/src/Clone.js
@@ -232,7 +232,17 @@ export class DocumentCloner {
         if (node instanceof HTMLStyleElement && node.sheet && node.sheet.cssRules) {
             const css = [].slice
                 .call(node.sheet.cssRules, 0)
-                .reduce((css, rule) => css + rule.cssText, '');
+                .reduce((css, rule) => {
+                    try {
+                        if (rule && rule.cssText) {
+                          return css + rule.cssText;
+                        }
+                        return css;
+                      } catch (err) {
+                        this.logger.log('Unable to access cssText property', rule.name);
+                        return css;
+                      }
+                });
             const style = node.cloneNode(false);
             style.textContent = css;
             return style;

--- a/src/Clone.js
+++ b/src/Clone.js
@@ -240,7 +240,7 @@ export class DocumentCloner {
                     this.logger.log('Unable to access cssText property', rule.name);
                     return css;
                 }
-            });
+            }, '');
             const style = node.cloneNode(false);
             style.textContent = css;
             return style;


### PR DESCRIPTION
https://github.com/niklasvh/html2canvas/issues/1374

Reproduced the above issue and located the cause, it happens in the createElementClone function when it attempts to access the cssText property, for some reason when using font-awesome, an element with fa-spin throws this error in IE when accessing the property.

Wrapping the property access in a try catch solves the immediate issue.