### PR TITLE
Revert "Fix underlines, relative to 'bottom' baseline"

### DIFF
--- a/src/renderer/CanvasRenderer.js
+++ b/src/renderer/CanvasRenderer.js
@@ -212,7 +212,7 @@ export default class CanvasRenderer implements RenderTarget<HTMLCanvasElement> {
                             const {baseline} = this.options.fontMetrics.getMetrics(font);
                             this.rectangle(
                                 text.bounds.left,
-                                Math.round(text.bounds.top + text.bounds.height - baseline),
+                                Math.round(text.bounds.top + baseline),
                                 text.bounds.width,
                                 1,
                                 textDecorationColor


### PR DESCRIPTION
This reverts commit 0c8d38d9c0659f532358a0d0c3250c1f813005fd.

As described [here](https://github.com/niklasvh/html2canvas/pull/1292#issuecomment-360700136), the underline fix I submitted was superseded by 38749bc. [This fiddle](http://jsfiddle.net/8rjbyqgj/) submitted by @FDIM illustrates that it is now causing a problem.

Related: #1292, #1364, #1394.