### PR TITLE
support blob image resources in non-foreignObjectRendering mode

### DIFF
--- a/src/ResourceLoader.js
+++ b/src/ResourceLoader.js
@@ -33,6 +33,10 @@ export default class ResourceLoader {
         if (this.hasResourceInCache(src)) {
             return src;
         }
+        if (isBlobImage(src)) {
+            this.cache[src] = loadImage(src, this.options.imageTimeout || 0);
+            return src;
+        }
 
         if (!isSVG(src) || FEATURES.SUPPORT_SVG_DRAWING) {
             if (this.options.allowTaint === true || isInlineImage(src) || this.isSameOrigin(src)) {
@@ -215,6 +219,7 @@ const INLINE_IMG = /^data:image\/.*/i;
 
 const isInlineImage = (src: string): boolean => INLINE_IMG.test(src);
 const isInlineBase64Image = (src: string): boolean => INLINE_BASE64.test(src);
+const isBlobImage = (src: string): boolean => src.substr(0, 4) === 'blob';
 
 const isSVG = (src: string): boolean =>
     src.substr(-3).toLowerCase() === 'svg' || INLINE_SVG.test(src);


### PR DESCRIPTION
**Summary**

This PR fixes/implements the following **bugs/features**

* [x] **fix bug** : support load blob image resources in non-foreignObjectRendering mode

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**motivation**
fix a bug: can not load a image resource when the image's url is blob format

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**problem reproduce**

https://jsfiddle.net/mapleeit/y6m87qwe/4/
