### PR TITLE
Add support for ES and browser bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "name": "html2canvas",
   "description": "Screenshots with JavaScript",
   "main": "dist/npm/index.js",
+  "module": "dist/html2canvas.js",
+  "browser": "dist/html2canvas.js",
   "version": "1.0.0-alpha.12",
   "author": {
     "name": "Niklas von Hertzen",


### PR DESCRIPTION
**Summary**

This PR implements the following features:

* [x] Add support for ES and browser bundlers

The `main` field in package.json points to `'dist/npm/index.js'`, which is ideal for CommonJS projects, however will fail on ES/browser bundlers because of the use of the undefined `process.env.NODE_ENV`.

This PR adds the fields `module` and `browser` to package.json, as defined [here](https://stackoverflow.com/a/42817320/4080966) and [here](https://github.com/dherman/defense-of-dot-js/blob/master/proposal.md#typical-usage) (module) and [here](https://github.com/defunctzombie/package-browser-field-spec) (browser). Both fields point to `dist/html2canvas.js`, which is built as UMD and will work with any format.

**Test plan (required)**

Create a new project, use ES syntax to `import` html2canvas, and use rollup or similar to bundle into UMD. The term `process.env.NODE_ENV` will no longer appear in the bundled code using this PR.

**Closing issues**

No matching issues found.
