### PR TITLE
Text-stroke and Paint-order support

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -12,9 +12,9 @@ Below is a list of all the supported CSS properties and values.
        - url()
        - linear-gradient()
        - radial-gradient()
-   - background-origin 
+   - background-origin
    - background-position
-   - background-size   
+   - background-size
  - border
    - border-color
    - border-radius
@@ -50,6 +50,7 @@ Below is a list of all the supported CSS properties and values.
  - overflow
  - overflow-wrap
  - padding
+ - paint-order
  - position
  - right
  - text-align
@@ -58,7 +59,8 @@ Below is a list of all the supported CSS properties and values.
    - text-decoration-line
    - text-decoration-style (**Only supports `solid`**)
  - text-shadow
- - text-transform 
+ - text-stroke (**with -webkit prefix**)
+ - text-transform
  - top
  - transform (**Limited support**)
  - visibility
@@ -68,7 +70,7 @@ Below is a list of all the supported CSS properties and values.
  - word-spacing
  - word-wrap
  - z-index
-    
+
 ## Unsupported CSS properties
 These CSS properties are **NOT** currently supported
  - [background-blend-mode](https://github.com/niklasvh/html2canvas/issues/966)
@@ -82,4 +84,3 @@ These CSS properties are **NOT** currently supported
  - [repeating-linear-gradient()](https://github.com/niklasvh/html2canvas/issues/1162)
  - [writing-mode](https://github.com/niklasvh/html2canvas/issues/1258)
  - [zoom](https://github.com/niklasvh/html2canvas/issues/732)
-

--- a/src/NodeContainer.js
+++ b/src/NodeContainer.js
@@ -12,7 +12,7 @@ import type {ListStyle} from './parsing/listStyle';
 import type {Margin} from './parsing/margin';
 import type {Overflow} from './parsing/overflow';
 import type {OverflowWrap} from './parsing/overflowWrap';
-import type {PaintOrder} from './parsing/paintOrder';
+import type {PaintLayer} from './parsing/paintOrder';
 import type {Padding} from './parsing/padding';
 import type {Position} from './parsing/position';
 import type {TextShadow} from './parsing/textShadow';
@@ -82,11 +82,11 @@ type StyleDeclaration = {
     overflow: Overflow,
     overflowWrap: OverflowWrap,
     padding: Padding,
-    paintOrder: PaintOrder,
+    paintOrder: Array<PaintLayer>,
     position: Position,
     textDecoration: TextDecoration | null,
     textShadow: Array<TextShadow> | null,
-    textStroke: TextStroke,
+    textStroke: TextStroke | null,
     textTransform: TextTransform,
     transform: Transform,
     visibility: Visibility,

--- a/src/NodeContainer.js
+++ b/src/NodeContainer.js
@@ -12,9 +12,11 @@ import type {ListStyle} from './parsing/listStyle';
 import type {Margin} from './parsing/margin';
 import type {Overflow} from './parsing/overflow';
 import type {OverflowWrap} from './parsing/overflowWrap';
+import type {PaintOrder} from './parsing/paintOrder';
 import type {Padding} from './parsing/padding';
 import type {Position} from './parsing/position';
 import type {TextShadow} from './parsing/textShadow';
+import type {TextStroke} from './parsing/textStroke';
 import type {TextTransform} from './parsing/textTransform';
 import type {TextDecoration} from './parsing/textDecoration';
 import type {Transform} from './parsing/transform';
@@ -43,9 +45,11 @@ import {parseMargin} from './parsing/margin';
 import {parseOverflow, OVERFLOW} from './parsing/overflow';
 import {parseOverflowWrap} from './parsing/overflowWrap';
 import {parsePadding} from './parsing/padding';
+import {parsePaintOrder} from './parsing/paintOrder';
 import {parsePosition, POSITION} from './parsing/position';
 import {parseTextDecoration} from './parsing/textDecoration';
 import {parseTextShadow} from './parsing/textShadow';
+import {parseTextStroke} from './parsing/textStroke';
 import {parseTextTransform} from './parsing/textTransform';
 import {parseTransform} from './parsing/transform';
 import {parseVisibility, VISIBILITY} from './parsing/visibility';
@@ -78,9 +82,11 @@ type StyleDeclaration = {
     overflow: Overflow,
     overflowWrap: OverflowWrap,
     padding: Padding,
+    paintOrder: PaintOrder,
     position: Position,
     textDecoration: TextDecoration | null,
     textShadow: Array<TextShadow> | null,
+    textStroke: TextStroke,
     textTransform: TextTransform,
     transform: Transform,
     visibility: Visibility,
@@ -154,9 +160,11 @@ export default class NodeContainer {
                 style.overflowWrap ? style.overflowWrap : style.wordWrap
             ),
             padding: parsePadding(style),
+            paintOrder: parsePaintOrder(style.paintOrder),
             position: position,
             textDecoration: parseTextDecoration(style),
             textShadow: parseTextShadow(style.textShadow),
+            textStroke: parseTextStroke(style.webkitTextStrokeWidth, style.webkitTextStrokeColor),
             textTransform: parseTextTransform(style.textTransform),
             transform: parseTransform(style),
             visibility: parseVisibility(style.visibility),

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -9,7 +9,7 @@ import type Logger from './Logger';
 import type {BackgroundImage} from './parsing/background';
 import type {Border, BorderSide} from './parsing/border';
 import type {Font} from './parsing/font';
-import type {PaintOrder} from './parsing/paintOrder';
+import type {PaintLayer} from './parsing/paintOrder';
 import type {TextDecoration} from './parsing/textDecoration';
 import type {TextShadow} from './parsing/textShadow';
 import type {TextStroke} from './parsing/textStroke';
@@ -83,7 +83,7 @@ export interface RenderTarget<Output> {
         textDecoration: TextDecoration | null,
         textShadows: Array<TextShadow> | null,
         textStroke: TextStroke | null,
-        paintOrder: PaintOrder | null
+        paintOrder: Array<PaintLayer>
     ): void,
 
     setOpacity(opacity: number): void,

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -9,8 +9,10 @@ import type Logger from './Logger';
 import type {BackgroundImage} from './parsing/background';
 import type {Border, BorderSide} from './parsing/border';
 import type {Font} from './parsing/font';
+import type {PaintOrder} from './parsing/paintOrder';
 import type {TextDecoration} from './parsing/textDecoration';
 import type {TextShadow} from './parsing/textShadow';
+import type {TextStroke} from './parsing/textStroke';
 import type {Matrix} from './parsing/transform';
 
 import type {BoundCurves} from './Bounds';
@@ -79,7 +81,9 @@ export interface RenderTarget<Output> {
         color: Color,
         font: Font,
         textDecoration: TextDecoration | null,
-        textShadows: Array<TextShadow> | null
+        textShadows: Array<TextShadow> | null,
+        textStroke: TextStroke | null,
+        paintOrder: PaintOrder | null
     ): void,
 
     setOpacity(opacity: number): void,
@@ -116,7 +120,9 @@ export default class Renderer {
                             style.color,
                             style.font,
                             style.textDecoration,
-                            style.textShadow
+                            style.textShadow,
+                            style.textStroke,
+                            style.paintOrder
                         );
                     } else {
                         this.target.drawShape(child, container.style.color);

--- a/src/parsing/paintOrder.js
+++ b/src/parsing/paintOrder.js
@@ -9,8 +9,6 @@ export const PAINT_LAYER = {
 
 export type PaintLayer = $Values<typeof PAINT_LAYER>;
 
-// export type PaintOrder = Array<PaintOrder>
-
 export const parsePaintOrder = (paintOrder: string): Array<PaintLayer> => {
     const order = paintOrder.split(' ');
 

--- a/src/parsing/paintOrder.js
+++ b/src/parsing/paintOrder.js
@@ -1,39 +1,38 @@
 /* @flow */
 'use strict';
 
-export const PAINT_ORDER = {
+export const PAINT_LAYER = {
     STROKE: 0,
     FILL: 1,
     MARKERS: 2
 };
 
-export type PaintOrder = {
-    order: array
-};
+export type PaintLayer = $Values<typeof PAINT_LAYER>;
 
-export const parsePaintOrder = (paintOrder: string): PaintOrder => {
-    const order = paintOrder.split(' ')
+// export type PaintOrder = Array<PaintOrder>
+
+export const parsePaintOrder = (paintOrder: string): Array<PaintLayer> => {
+    const order = paintOrder.split(' ');
 
     if (order[0] === 'normal') {
-        return {order: [PAINT_ORDER.FILL, PAINT_ORDER.STROKE, PAINT_ORDER.MARKERS]}
+        return [PAINT_LAYER.FILL, PAINT_LAYER.STROKE, PAINT_LAYER.MARKERS];
     }
 
-    const layers = order.map(layer => {
+    const layers = [];
+
+    order.forEach(layer => {
         switch (layer) {
             case 'stroke':
-                layer = PAINT_ORDER.STROKE;
+                layers.push(PAINT_LAYER.STROKE);
                 break;
             case 'fill':
-                layer = PAINT_ORDER.FILL;
+                layers.push(PAINT_LAYER.FILL);
                 break;
             case 'markers':
-                layer = PAINT_ORDER.MARKERS;
+                layers.push(PAINT_LAYER.MARKERS);
                 break;
         }
-        return layer;
-    })
+    });
 
-    return {
-        order: layers
-    }
+    return layers;
 };

--- a/src/parsing/paintOrder.js
+++ b/src/parsing/paintOrder.js
@@ -1,0 +1,39 @@
+/* @flow */
+'use strict';
+
+export const PAINT_ORDER = {
+    STROKE: 0,
+    FILL: 1,
+    MARKERS: 2
+};
+
+export type PaintOrder = {
+    order: array
+};
+
+export const parsePaintOrder = (paintOrder: string): PaintOrder => {
+    const order = paintOrder.split(' ')
+
+    if (order[0] === 'normal') {
+        return {order: [PAINT_ORDER.FILL, PAINT_ORDER.STROKE, PAINT_ORDER.MARKERS]}
+    }
+
+    const layers = order.map(layer => {
+        switch (layer) {
+            case 'stroke':
+                layer = PAINT_ORDER.STROKE;
+                break;
+            case 'fill':
+                layer = PAINT_ORDER.FILL;
+                break;
+            case 'markers':
+                layer = PAINT_ORDER.MARKERS;
+                break;
+        }
+        return layer;
+    })
+
+    return {
+        order: layers
+    }
+};

--- a/src/parsing/textStroke.js
+++ b/src/parsing/textStroke.js
@@ -1,0 +1,18 @@
+/* @flow */
+'use strict';
+
+import Color from '../Color';
+
+export type TextStroke = {
+    color: Color,
+    size: string,
+};
+export const parseTextStroke = (textStrokeWidth: string, textStrokeColor: string): TextStroke => {
+    const color = new Color(textStrokeColor);
+    const size = parseInt(textStrokeWidth);
+
+    return {
+        color,
+        size
+    };
+};

--- a/src/parsing/textStroke.js
+++ b/src/parsing/textStroke.js
@@ -5,11 +5,19 @@ import Color from '../Color';
 
 export type TextStroke = {
     color: Color,
-    size: string,
+    size: number
 };
-export const parseTextStroke = (textStrokeWidth: string, textStrokeColor: string): TextStroke => {
+
+export const parseTextStroke = (
+    textStrokeWidth: string,
+    textStrokeColor: string
+): TextStroke | null => {
     const color = new Color(textStrokeColor);
-    const size = parseInt(textStrokeWidth);
+    const size = parseFloat(textStrokeWidth);
+
+    if (size <= 0) {
+        return null;
+    }
 
     return {
         color,

--- a/src/renderer/CanvasRenderer.js
+++ b/src/renderer/CanvasRenderer.js
@@ -296,7 +296,7 @@ export default class CanvasRenderer implements RenderTarget<HTMLCanvasElement> {
                     case PAINT_LAYER.STROKE:
                         if (textStroke && text.text.trim().length) {
                             this.ctx.strokeStyle = textStroke.color.toString();
-                            this.ctx.lineWidth = textStroke.size; // * 1.5
+                            this.ctx.lineWidth = textStroke.size;
 
                             this.ctx.strokeText(
                                 text.text,

--- a/src/renderer/RefTestRenderer.js
+++ b/src/renderer/RefTestRenderer.js
@@ -8,12 +8,14 @@ import type {Path} from '../drawing/Path';
 import type Size from '../drawing/Size';
 
 import type {Font} from '../parsing/font';
+import type {PaintLayer} from '../parsing/paintOrder';
 import type {
     TextDecoration,
     TextDecorationStyle,
     TextDecorationLine
 } from '../parsing/textDecoration';
 import type {TextShadow} from '../parsing/textShadow';
+import type {TextStroke} from '../parsing/textStroke';
 import type {Matrix} from '../parsing/transform';
 
 import type {Bounds} from '../Bounds';
@@ -163,7 +165,9 @@ class RefTestRenderer implements RenderTarget<string> {
         color: Color,
         font: Font,
         textDecoration: TextDecoration | null,
-        textShadows: Array<TextShadow> | null
+        textShadows: Array<TextShadow> | null,
+        textStroke: TextStroke | null,
+        paintOrder: Array<PaintLayer>
     ) {
         const fontString = [
             font.fontStyle,

--- a/tests/reftests/text/stroke.html
+++ b/tests/reftests/text/stroke.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Text stroke tests</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <script type="text/javascript" src="../../test.js"></script>
+    <style>
+        div span:first-child {
+            font-size: 2em;
+        }
+        div span:nth-child(2) {
+            font-size: 5em;
+        }
+
+        .stroke1 {
+            -webkit-text-stroke-width: .09em;
+            -webkit-text-stroke-color: red;
+            font-size: 1em;
+        }
+        .stroke2 {
+            -webkit-text-stroke-width: .12em;
+            -webkit-text-stroke-color: green;
+            font-size: 2em;
+        }
+        .stroke3 {
+            -webkit-text-stroke-width: .19em;
+            -webkit-text-stroke-color: blue;
+            font-size: 3em;
+        }
+
+        .ordered {
+            paint-order: stroke fill;
+        }
+
+        body {
+            font-family: Arial;
+        }
+    </style>
+</head>
+<body>
+<div class="stroke1">
+    Some text <span> with bigger text </span> that should have a stroke
+    <strong>Bolder stroke</strong> that makes things pretty
+</div>
+<div class="stroke2">
+    Some text <span> with bigger text </span> that should have a stroke
+    <strong>Bolder stroke</strong> that makes things pretty
+</div>
+<div class="stroke3">
+    Some text <span> with bigger text </span> that should have a stroke
+    <strong>Bolder stroke</strong> that makes things pretty
+</div>
+<div class="stroke1 ordered">
+    Some text <span> with bigger text </span> that should have a stroke
+    <strong>Bolder stroke</strong> that makes things pretty
+</div>
+<div class="stroke2 ordered">
+    Some text <span> with bigger text </span> that should have a stroke
+    <strong>Bolder stroke</strong> that makes things pretty
+</div>
+<div class="stroke3 ordered">
+    Some text <span> with bigger text </span> that should have a stroke
+    <strong>Bolder stroke</strong> that makes things pretty
+</div>
+<div class="stroke4">
+    Some text <span> with bigger text </span> that should have no stroke
+    <strong>Bolder text</strong> that makes things pretty
+</div>
+</html>


### PR DESCRIPTION
This ads support for `-webkit-text-stroke`, `-webkit-text-stroke-width`, `-webkit-text-stroke-color`, and `paint-order`. 

Note that even through these are webkit prefixes, Firefox still uses them.

`paint-order` is required in order to get strokes to render as an outline of the text and not in the middle.

`paint-order` does not currently work fully in chrome, as chrome reads the value of the property, but does not apply it in the dom. Firefox and Safari work just fine.

See `tests/text/stroke.html` for an example

---

Fixes #759 and #1108
