### PR TITLE
Attempt to include flex-wrap and justify-content

### DIFF
--- a/src/NodeContainer.js
+++ b/src/NodeContainer.js
@@ -6,6 +6,7 @@ import type {Border} from './parsing/border';
 import type {BorderRadius} from './parsing/borderRadius';
 import type {DisplayBit} from './parsing/display';
 import type {Float} from './parsing/float';
+import type {FlexWrap, JustifyContent} from './parsing/flex';
 import type {Font} from './parsing/font';
 import type {LineBreak} from './parsing/lineBreak';
 import type {ListStyle} from './parsing/listStyle';
@@ -36,6 +37,7 @@ import {parseBorderRadius} from './parsing/borderRadius';
 import {parseDisplay, DISPLAY} from './parsing/display';
 import {parseCSSFloat, FLOAT} from './parsing/float';
 import {parseFont} from './parsing/font';
+import {parseFlexWrap, parseJustifyContent} from './parsing/flex';
 import {parseLetterSpacing} from './parsing/letterSpacing';
 import {parseLineBreak} from './parsing/lineBreak';
 import {parseListStyle} from './parsing/listStyle';
@@ -69,6 +71,8 @@ type StyleDeclaration = {
     color: Color,
     display: DisplayBit,
     float: Float,
+    flexWrap: FlexWrap,
+    justifyContent: JustifyContent,
     font: Font,
     letterSpacing: number,
     lineBreak: LineBreak,
@@ -140,6 +144,8 @@ export default class NodeContainer {
             color: IS_INPUT ? INPUT_COLOR : new Color(style.color),
             display: display,
             float: parseCSSFloat(style.float),
+            flexWrap: parseFlexWrap(style.flexWrap),
+            justifyContent: parseJustifyContent(style.justifyContent),
             font: parseFont(style),
             letterSpacing: parseLetterSpacing(style.letterSpacing),
             listStyle: display === DISPLAY.LIST_ITEM ? parseListStyle(style) : null,

--- a/src/parsing/flex.js
+++ b/src/parsing/flex.js
@@ -1,0 +1,23 @@
+/* @flow */
+'use strict';
+
+export const FLEX_WRAP = {
+    NOWRAP: 0,
+    WRAP: 1,
+    WRAP_REVERSE: 2
+};
+
+export type FlexWrap = $Values<typeof FLEX_WRAP>;
+
+export const parseFlexWrap = (flexWrap: string): FlexWrap => {
+    switch (flexWrap) {
+        case 'nowrap':
+            return FLEX_WRAP.NOWRAP;
+        case 'wrap':
+            return FLEX_WRAP.WRAP;
+        case 'wrap-reverse':
+            return FLEX_WRAP.WRAP_REVERSE;
+        default:
+            return FLEX_WRAP.NOWRAP;
+    }
+};

--- a/src/parsing/flex.js
+++ b/src/parsing/flex.js
@@ -21,3 +21,30 @@ export const parseFlexWrap = (flexWrap: string): FlexWrap => {
             return FLEX_WRAP.NOWRAP;
     }
 };
+
+export const JUSTIFY_CONTENT = {
+    FLEX_START: 0,
+    FLEX_END: 1,
+    CENTER: 2,
+    SPACE_BETWEEN: 3,
+    SPACE_AROUND: 4
+};
+
+export type JustifyContent = $Values<typeof JUSTIFY_CONTENT>;
+
+export const parseJustifyContent = (justifyContent: string): JustifyContent => {
+    switch (justifyContent) {
+        case 'flex-start':
+            return JUSTIFY_CONTENT.FLEX_START;
+        case 'flex-end':
+            return JUSTIFY_CONTENT.FLEX_END;
+        case 'center':
+            return JUSTIFY_CONTENT.CENTER;
+        case 'space-between':
+            return JUSTIFY_CONTENT.SPACE_BETWEEN;
+        case 'space-around':
+            return JUSTIFY_CONTENT.SPACE_AROUND;
+        default:
+            return JUSTIFY_CONTENT.FLEX_START;
+    }
+};


### PR DESCRIPTION
I tried to include flex-wrap and justify-content from flexbox. npm test was sucessfull.
It doesn't seem to change the behaviour of the canvas drawing. Maybe I forgot something?
these css properties should be easy to include because its naturally supported by chrome.