### PR TITLE
Fix CSS content property for Safari

### DIFF
--- a/src/PseudoNodeContent.js
+++ b/src/PseudoNodeContent.js
@@ -311,6 +311,8 @@ const addOtherToken = (tokens: Array<Token>, identifier: string): void => {
         case 'close-quote':
             tokens.push({type: TOKEN_TYPE.CLOSEQUOTE});
             break;
+        default:
+            tokens.push({type: TOKEN_TYPE.STRING, value: identifier});
     }
 };
 

--- a/tests/node/pseudonodecontent.js
+++ b/tests/node/pseudonodecontent.js
@@ -7,7 +7,11 @@ describe('PseudoNodeContent', function() {
             {type: PseudoNodeContent.TOKEN_TYPE.STRING, value: 'hello'}
         ]);
     });
-
+    it('should parse string', function() {
+        assert.deepEqual(PseudoNodeContent.parseContent('safari'), [
+            {type: PseudoNodeContent.TOKEN_TYPE.STRING, value: 'safari'}
+        ]);
+    });
     it('should parse string with (,)', function() {
         assert.deepEqual(PseudoNodeContent.parseContent('"a,b (c) d"'), [
             {type: PseudoNodeContent.TOKEN_TYPE.STRING, value: 'a,b (c) d'}


### PR DESCRIPTION
Safari does not pass content strings in double quotes, so they get ignored. This breaks packages such as Font-Awesome on Safari and iOS.

Fixes #1610 
