### PR TITLE
fixes #1593

### DIFF
--- a/src/Clone.js
+++ b/src/Clone.js
@@ -225,7 +225,10 @@ export class DocumentCloner {
                                 );
                             }
                         })
-                );
+                )
+                .catch(() => {
+                    // avoid Angular ngZone error
+                });
             return tempIframe;
         }
 


### PR DESCRIPTION
Angular `ngZone` throws an error due to an uncaught `Promise.reject()`. This PR adds the necessary `catch`