### PR TITLE
Wrap .sheet.cssRules access in try...catch.

### DIFF
--- a/src/Clone.js
+++ b/src/Clone.js
@@ -229,22 +229,32 @@ export class DocumentCloner {
             return tempIframe;
         }
 
-        if (node instanceof HTMLStyleElement && node.sheet && node.sheet.cssRules) {
-            const css = [].slice.call(node.sheet.cssRules, 0).reduce((css, rule) => {
-                try {
-                    if (rule && rule.cssText) {
-                        return css + rule.cssText;
-                    }
-                    return css;
-                } catch (err) {
-                    this.logger.log('Unable to access cssText property', rule.name);
-                    return css;
-                }
-            }, '');
-            const style = node.cloneNode(false);
-            style.textContent = css;
-            return style;
-        }
+try {
+const css = [].slice.call(node.sheet.cssRules, 0).reduce((css, rule) => {
+if (node instanceof HTMLStyleElement && node.sheet && node.sheet.cssRules) {
+ const css = [].slice.call(node.sheet.cssRules, 0).reduce((css, rule) => {
+								 if (rule && rule.cssText) {
+								 if (rule && rule.cssText) {
+									 return css + rule.cssText;
+									 return css + rule.cssText;
+								 }
+								 }
+								 return css;
+								 return css;
+}, '');
+const style = node.cloneNode(false);
+style.textContent = css;
+return style;
+}
+} catch (e) {
+// accessing node.sheet.cssRules throws a DOMException
+this.logger.log('Unable to access cssRules property');
+if (e.name !== 'SecurityError') {
+this.logger.log(e);
+throw e;
+}
+}
+}
 
         return node.cloneNode(false);
     }

--- a/src/Clone.js
+++ b/src/Clone.js
@@ -229,32 +229,26 @@ export class DocumentCloner {
             return tempIframe;
         }
 
-try {
-const css = [].slice.call(node.sheet.cssRules, 0).reduce((css, rule) => {
-if (node instanceof HTMLStyleElement && node.sheet && node.sheet.cssRules) {
- const css = [].slice.call(node.sheet.cssRules, 0).reduce((css, rule) => {
-								 if (rule && rule.cssText) {
-								 if (rule && rule.cssText) {
-									 return css + rule.cssText;
-									 return css + rule.cssText;
-								 }
-								 }
-								 return css;
-								 return css;
-}, '');
-const style = node.cloneNode(false);
-style.textContent = css;
-return style;
-}
-} catch (e) {
-// accessing node.sheet.cssRules throws a DOMException
-this.logger.log('Unable to access cssRules property');
-if (e.name !== 'SecurityError') {
-this.logger.log(e);
-throw e;
-}
-}
-}
+        try {
+            if (node instanceof HTMLStyleElement && node.sheet && node.sheet.cssRules) {
+                const css = [].slice.call(node.sheet.cssRules, 0).reduce((css, rule) => {
+                    if (rule && rule.cssText) {
+                        return css + rule.cssText;
+                    }
+                    return css;
+                }, '');
+                const style = node.cloneNode(false);
+                style.textContent = css;
+                return style;
+            }
+        } catch (e) {
+            // accessing node.sheet.cssRules throws a DOMException
+            this.logger.log('Unable to access cssRules property');
+            if (e.name !== 'SecurityError') {
+                this.logger.log(e);
+                throw e;
+            }
+        }
 
         return node.cloneNode(false);
     }


### PR DESCRIPTION
**Summary**

Wrap accesses to .sheet.cssRules in a try...catch block. On Firefox, this access can cause a DOMException to be thrown ('SecurityError') which interrupts the entire process. Log-and-resume to avoid it.

This PR fixes/implements the following **bugs/features**

* [node.sheet.cssRules accessed outside of try-catch, so the thrown DOMException is uncaught #1673](https://github.com/niklasvh/html2canvas/issues/1673) Bug 1

Explain the **motivation** for making this change. What existing problem does the pull request solve?

The uncaught exception means that the entire html2canvas operation is interrupted and no image is produced. At least for our application, the cssRule can be safely ignored.

**Test plan (required)**

I'm still working on this. Adding a file into tests/reftests isn't working because the documents don't get cloned first before copying them.

**Code formatting**

Please make sure that code adheres to the project code formatting. Running `npm run format` will automatically format your code correctly.

**Closing issues**
closes #1673 

