### PR TITLE
ci: test Node.js 4, 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 node_js:
-- '7'
+- 'node'
+- '10'
+- '8'
+- '6'
+- '4'
 env:
   global:
   - secure: eW41gIqOizwO4pTgWnAAbW75AP7F+CK9qfSed/fSh4sJ9HWMIY1YRIaY8gjr+6jV/f7XVHcXuym6ZxgINYSkVKbF1JKxBJNLOXtSgNbVHSic58pYFvUjwxIBI9aPig9uux1+DbnpWqXFDTcACJSevQZE0xwmjdrSkDLgB0G34v8=

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ notifications:
     on_success: always
     on_failure: always
     on_start: false
+install: npm install
 script:
   - npm run build
   - cd www && npm install && npm run build && cd ..


### PR DESCRIPTION
We should test the supported versions (see `engines` field in package.json).
Also just even releases are supported and LTS, 7 and other odd release numbers already reached their EOL.