### PR TITLE
Fix custom font-family's not loaded on text nodes

### DIFF
--- a/src/NodeContainer.js
+++ b/src/NodeContainer.js
@@ -273,6 +273,16 @@ const getImage = (node: HTMLElement | SVGSVGElement, resourceLoader: ResourceLoa
         node instanceof node.ownerDocument.defaultView.SVGSVGElement ||
         node instanceof SVGSVGElement
     ) {
+        var svgElem = node.getElementsByTagName('text');
+        for (const n of svgElem) {
+            if (window.getComputedStyle(node, null).getPropertyValue('font-family')) {
+                n.setAttribute(
+                    'font-family',
+                    window.getComputedStyle(node, null).getPropertyValue('font-family')
+                );
+                n.replaceWith(n);
+            }
+        }
         const s = new XMLSerializer();
         return resourceLoader.loadImage(
             `data:image/svg+xml,${encodeURIComponent(s.serializeToString(node))}`


### PR DESCRIPTION
**Summary**

Looks for text nodes in an SVG and adds the font-family attribute whenever a font-family was added. This will make sure that custom fonts load properly on svg elements.

This PR fixes/implements the following **bugs/features**

* [ ] #1463 
* [ ] #1709 

Solves the issues listed above

**Test plan (required)**
Add a custom font with `@font-face`, use the custom font in a css class and add the class to a svg text element

**Code formatting**

Please make sure that code adheres to the project code formatting. Running `npm run format` will automatically format your code correctly.

**Closing issues**

closes #1463, #1709
