### PR TITLE
Enforce colorstop min 0

### DIFF
--- a/src/renderer/CanvasRenderer.js
+++ b/src/renderer/CanvasRenderer.js
@@ -26,7 +26,10 @@ const addColorStops = (
     const maxStop = Math.max.apply(null, gradient.colorStops.map(colorStop => colorStop.stop));
     const f = 1 / Math.max(1, maxStop);
     gradient.colorStops.forEach(colorStop => {
-        canvasGradient.addColorStop(Math.floor(Math.max(0, f * colorStop.stop)), colorStop.color.toString());
+        canvasGradient.addColorStop(
+            Math.floor(Math.max(0, f * colorStop.stop)),
+            colorStop.color.toString()
+        );
     });
 };
 

--- a/src/renderer/CanvasRenderer.js
+++ b/src/renderer/CanvasRenderer.js
@@ -26,7 +26,7 @@ const addColorStops = (
     const maxStop = Math.max.apply(null, gradient.colorStops.map(colorStop => colorStop.stop));
     const f = 1 / Math.max(1, maxStop);
     gradient.colorStops.forEach(colorStop => {
-        canvasGradient.addColorStop(f * colorStop.stop, colorStop.color.toString());
+        canvasGradient.addColorStop(Math.floor(Math.max(0, f * colorStop.stop)), colorStop.color.toString());
     });
 };
 


### PR DESCRIPTION
In our experience, it's possible for the colorstop.stop to be less than zero, but only in Firefox. When this happens, you get the dreaded "IndexSizeError: Index or size is negative or greater than the allowed amount".

This often manifests as -0 or a very small negative number, so it seems pretty safe to just force this to zero.

Replicating this error is not easy and I don't currently have a live site to demonstrate it with, so I'll try to find out more. We're currently patching dist/html2canvas.js.