### PR TITLE
check if resize dimensions NaN

### DIFF
--- a/src/renderer/CanvasRenderer.js
+++ b/src/renderer/CanvasRenderer.js
@@ -288,6 +288,10 @@ export default class CanvasRenderer implements RenderTarget<HTMLCanvasElement> {
             return image;
         }
 
+        if (isNaN(size.width) || isNaN(size.height)) {
+            return image;
+        }
+
         const canvas = this.canvas.ownerDocument.createElement('canvas');
         canvas.width = size.width;
         canvas.height = size.height;


### PR DESCRIPTION
Similar to #1743 , we find that only in Firefox requested image dimensions can be NaN. This is a quick check before drawImage is called.