### PR TITLE
Prevent unhandled promise rejections for hidden frames

### DIFF
--- a/src/Clone.js
+++ b/src/Clone.js
@@ -213,7 +213,12 @@ export class DocumentCloner {
                         new Promise((resolve, reject) => {
                             const iframeCanvas = document.createElement('img');
                             iframeCanvas.onload = () => resolve(canvas);
-                            iframeCanvas.onerror = reject;
+                            iframeCanvas.onerror = function(event) {
+                                // Empty iframes may result in empty "data:," URLs, which are invalid from the <img>'s point of view
+                                // and instead of `onload` cause `onerror` and unhandled rejection warnings
+                                // https://github.com/niklasvh/html2canvas/issues/1502
+                                iframeCanvas.src == 'data:,' ? resolve(canvas) : reject(event);
+                            };
                             iframeCanvas.src = canvas.toDataURL();
                             if (tempIframe.parentNode) {
                                 tempIframe.parentNode.replaceChild(


### PR DESCRIPTION
Fixes the problem outlined in https://github.com/niklasvh/html2canvas/issues/1502#issuecomment-466501044

**Test plan (required)** - TODO

Demonstrate how the issue/feature can be replicated. For most cases, simply adding an appropriate html/css template into the [reftests](https://github.com/niklasvh/html2canvas/tree/master/tests/reftests) should be sufficient. Please see other tests there for reference.