### PR TITLE
Sets the context scale for high resolution displays

### DIFF
--- a/src/renderer/ForeignObjectRenderer.js
+++ b/src/renderer/ForeignObjectRenderer.js
@@ -16,6 +16,7 @@ export default class ForeignObjectRenderer {
         this.canvas.height = Math.floor(options.height) * options.scale;
         this.canvas.style.width = `${options.width}px`;
         this.canvas.style.height = `${options.height}px`;
+        this.ctx.scale(options.scale, options.scale);
 
         options.logger.log(
             `ForeignObject renderer initialized (${options.width}x${options.height} at ${options.x},${options.y}) with scale ${options.scale}`


### PR DESCRIPTION


**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ ] Bug #1781


<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

On high resolution displays (where `defaultView.devicePixelRatio` is greater than `1`), the rendered output will only take some fraction of the entire canvas.  This is because twice as many pixels need to be written out.  

This calls `this.context.scale(...)` to normalize coordinate system to use css pixels. This technique is shown on [mdn](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio#Example). This fixes the problem.

**Test plan (required)**

I'm not sure how to test this without running tests on a machine that has a high resolution display.



**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #

Closes #1781