### PR TITLE
1374: Fixed Member not found error in IE11 for cssText

### DIFF
--- a/src/Clone.js
+++ b/src/Clone.js
@@ -236,7 +236,7 @@ export class DocumentCloner {
         try {
             if (node instanceof HTMLStyleElement && node.sheet && node.sheet.cssRules) {
                 const css = [].slice.call(node.sheet.cssRules, 0).reduce((css, rule) => {
-                    if (rule && rule.cssText) {
+                    if (rule && typeof rule.cssText === 'string') {
                         return css + rule.cssText;
                     }
                     return css;


### PR DESCRIPTION
**Summary**
  This PR fixes the `Member not found` issue from IE11.  Although the actual problem is fixed as part of https://github.com/niklasvh/html2canvas/pull/1415 But the problem still persists in IE11. 
I think the change here is self-explanatory.
Thanks :)

This PR fixes the following **bugs**

* [x] #1374 
* [x] #1432 

Fixes #1374 
