### PR TITLE
fix: zero size iframe rendering (#1668)

### DIFF
--- a/src/dom/replaced-elements/iframe-element-container.ts
+++ b/src/dom/replaced-elements/iframe-element-container.ts
@@ -15,8 +15,8 @@ export class IFrameElementContainer extends ElementContainer {
     constructor(iframe: HTMLIFrameElement) {
         super(iframe);
         this.src = iframe.src;
-        this.width = parseInt(iframe.width, 10);
-        this.height = parseInt(iframe.height, 10);
+        this.width = parseInt(iframe.width, 10) || 0;
+        this.height = parseInt(iframe.height, 10) || 0;
         this.backgroundColor = this.styles.backgroundColor;
         try {
             if (

--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -306,17 +306,19 @@ export class CanvasRenderer {
             });
 
             const canvas = await iframeRenderer.render(container.tree);
-            this.ctx.drawImage(
-                canvas,
-                0,
-                0,
-                container.width,
-                container.width,
-                container.bounds.left,
-                container.bounds.top,
-                container.bounds.width,
-                container.bounds.height
-            );
+            if (container.width && container.height) {
+                this.ctx.drawImage(
+                    canvas,
+                    0,
+                    0,
+                    container.width,
+                    container.height,
+                    container.bounds.left,
+                    container.bounds.top,
+                    container.bounds.width,
+                    container.bounds.height
+                );
+            }
         }
 
         if (container instanceof InputElementContainer) {


### PR DESCRIPTION
**Summary**

- if an iframe has not specified width or height it parsed to NaN
- Canvas drawImage throw error when try to draw 0 size image

Fixes #1668 
