### PR TITLE
add missing -ms-grid display property to support IE grid layouts

### DIFF
--- a/src/css/property-descriptors/display.ts
+++ b/src/css/property-descriptors/display.ts
@@ -65,6 +65,7 @@ const parseDisplayValue = (display: string): Display => {
         case '-webkit-flex':
             return DISPLAY.FLEX;
         case 'grid':
+        case '-ms-grid':
             return DISPLAY.GRID;
         case 'ruby':
             return DISPLAY.RUBY;


### PR DESCRIPTION
A similar PR may already be submitted!
Please search among the [Pull request](https://github.com/niklasvh/html2canvas/pulls) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

Before opening a pull request, please make sure all the tests pass locally by running `npm test`.

**Summary**

Since IE uses the -ms-grid display property instead of the grid property, the display property list was missing this tag. This caused empty rendering for grid layouts on IE.

This PR fixes/implements the following **bugs/features**

* [ x ] Bug 1
* [ ] Bug 2
* [ ] Feature 1
* [ ] Feature 2
* [ ] Breaking changes

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

In IE with a grid layout the library produces an empty image, due to the missing display property (-ms-grid).

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Create a HTML node with CSS grid (use -ms-grid autoperfixer). Try to create an image of this node in IE. Due to the missing property the image is empty and the node is not rendered correctly.

Demonstrate how the issue/feature can be replicated. For most cases, simply adding an appropriate html/css template into the [reftests](https://github.com/niklasvh/html2canvas/tree/master/tests/reftests) should be sufficient. Please see other tests there for reference.

**Code formatting**

Please make sure that code adheres to the project code formatting. Running `npm run format` will automatically format your code correctly.

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
