### PR TITLE
support font-family names with numbers in (e.g. Font Awesome 5)

### DIFF
--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -155,7 +155,7 @@ export class CanvasRenderer {
         const fontVariant = styles.fontVariant
             .filter(variant => variant === 'normal' || variant === 'small-caps')
             .join('');
-        const fontFamily = styles.fontFamily.join(', ');
+        const fontFamily = styles.fontFamily.map(fontFamily => `"${fontFamily}"`).join(', ');
         const fontSize = isDimensionToken(styles.fontSize)
             ? `${styles.fontSize.number}${styles.fontSize.unit}`
             : `${styles.fontSize.number}px`;

--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -155,7 +155,9 @@ export class CanvasRenderer {
         const fontVariant = styles.fontVariant
             .filter(variant => variant === 'normal' || variant === 'small-caps')
             .join('');
-        const fontFamily = styles.fontFamily.map(fontFamily => `"${fontFamily}"`).join(', ');
+        const fontFamily = styles.fontFamily.map(fontName => {
+            return fontName.indexOf(' ') === -1 ? fontName : `"${fontName}"`;
+        }).join(', ');
         const fontSize = isDimensionToken(styles.fontSize)
             ? `${styles.fontSize.number}${styles.fontSize.unit}`
             : `${styles.fontSize.number}px`;


### PR DESCRIPTION
**Summary**

Font-Awesome 5 icons are being rendered as squares. This is because the Font-Awesome 5 font family contains a number, which then causes issues when setting the font property on the canvas context. This fixes the issue by wrapping font family names in quotes.

This PR fixes/implements the following **bugs/features**

* [ ] #1881