### PR TITLE
fix boarder fix #1920

### DIFF
--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -696,10 +696,11 @@ export class CanvasRenderer {
                 });
         }
 
-        let side = 0;
+        let side = -1;
         for (const border of borders) {
+            side++
             if (border.style !== BORDER_STYLE.NONE && !isTransparent(border.color)) {
-                await this.renderBorder(border.color, side++, paint.curves);
+                await this.renderBorder(border.color, side, paint.curves);
             }
         }
     }


### PR DESCRIPTION
Fix problem with render boarder. Variable side is increment only if condition is true. But if you have only boarder-top and boarder-bottom, them boarder-bottom render it like border-left.