### PR TITLE
fix zindex bug

### DIFF
--- a/src/render/stacking-context.ts
+++ b/src/render/stacking-context.ts
@@ -104,7 +104,6 @@ const parseStackTree = (
                     parentStack.negativeZIndex.some((current, i) => {
                         if (order > current.element.container.styles.zIndex.order) {
                             index = i;
-                            return true;
                         }
                         return false;
                     });
@@ -114,7 +113,6 @@ const parseStackTree = (
                     parentStack.positiveZIndex.some((current, i) => {
                         if (order > current.element.container.styles.zIndex.order) {
                             index = i + 1;
-                            return true;
                         }
 
                         return false;


### PR DESCRIPTION
Since my English sucks, machine translation can only be translated!
i found one problem.
if we have a html like:
https://codepen.io/tianchouczl/pen/PoYGOQK

if the numbers of absolute positioning div > 2 have this bug

in stacking-context.ts lines:113-122
`let index = 0;
 parentStack.positiveZIndex.some((current, i) => {
   if (order > current.element.container.styles.zIndex.order) {
        index = i + 1;
         return true;
  }
  return false;
});
parentStack.positiveZIndex.splice(index, 0, stack);`

this index not true. we should found the index which is less then order.but this code, if u got the first order less then order, u return true.This is not what we want.
example:
if  parentStack.positiveZIndex have two index [1,2]
and we give a order = 3
in this code ,we got  parentStack.positiveZIndex = [1,3,2],
but we need [1,2,3]