### PR TITLE
fix: #1868 Clone node, Setting className for SVG element raises error

### DIFF
--- a/src/dom/document-cloner.ts
+++ b/src/dom/document-cloner.ts
@@ -322,7 +322,7 @@ export class DocumentCloner {
 
     resolvePseudoContent(
         node: Element,
-        clone: Element,
+        clone: Element | SVGElement,
         style: CSSStyleDeclaration,
         pseudoElt: PseudoElementType
     ): HTMLElement | void {
@@ -409,10 +409,17 @@ export class DocumentCloner {
         });
 
         anonymousReplacedElement.className = `${PSEUDO_HIDE_ELEMENT_CLASS_BEFORE} ${PSEUDO_HIDE_ELEMENT_CLASS_AFTER}`;
-        clone.className +=
+        const newClassName =
             pseudoElt === PseudoElementType.BEFORE
                 ? ` ${PSEUDO_HIDE_ELEMENT_CLASS_BEFORE}`
                 : ` ${PSEUDO_HIDE_ELEMENT_CLASS_AFTER}`;
+
+        if (isSVGElement(clone)) {
+            clone.className.baseValue += newClassName;
+        } else {
+            clone.className += newClassName;
+        }
+
         return anonymousReplacedElement;
     }
 
@@ -423,6 +430,10 @@ export class DocumentCloner {
         }
         return false;
     }
+}
+
+function isSVGElement(element: Element | SVGElement): element is SVGElement {
+    return typeof (element as SVGElement).className === 'object';
 }
 
 enum PseudoElementType {


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ ] #1868

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

See #1868. The definition of className differs for Element and SVGElement. In Element className it is a string, but in SVG element class name it is a instance of SVGAnimatedString.

References: [https://developer.mozilla.org/en-US/docs/Web/API/Element/className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className)
[https://developer.mozilla.org/en-US/docs/Web/API/SVGAnimatedString](https://developer.mozilla.org/en-US/docs/Web/API/SVGAnimatedString)


**Code formatting**

Please make sure that code adheres to the project code formatting. Running `npm run format` will automatically format your code correctly.

**Closing issues**

fixes #1868
closes #1868 
