### PR TITLE
Fix error in server-side rendering (SSR)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,9 @@ const html2canvas = (element: HTMLElement, options: Partial<Options> = {}): Prom
 
 export default html2canvas;
 
-CacheStorage.setContext(window);
+if (typeof window !== "undefined") {
+    CacheStorage.setContext(window);
+}
 
 const renderElement = async (element: HTMLElement, opts: Partial<Options>): Promise<HTMLCanvasElement> => {
     const ownerDocument = element.ownerDocument;


### PR DESCRIPTION
> A similar PR may already be submitted!
> Please search among the [Pull request](https://github.com/niklasvh/html2canvas/pulls) before creating one.

> Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

> Before opening a pull request, please make sure all the tests pass locally by running `npm test`.

**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] #1901
* [x] #1909
* [x] (possibly) #2015 

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

> Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

`html2canvas` causes JavaScript applications that use server-side rendering (e.g. via Next.js, Nuxt, Gatsby, Gridsome) to break as the `CacheStorage.setContext(window)` call that is executed on import tries to access the `window` variable that does not exist in Node.

Obviously, this won't fix the actual functionality of taking a screenshot in Node, but it will allow for apps that use SRR to be pre-rendered on the server and then delivered to the client, where it will then be possible to use this library take screenshots.

**Test plan (required)**

> Demonstrate how the issue/feature can be replicated. For most cases, simply adding an appropriate html/css template into the [reftests](https://github.com/niklasvh/html2canvas/tree/master/tests/reftests) should be sufficient. Please see other tests there for reference.

**Code formatting**

> Please make sure that code adheres to the project code formatting. Running `npm run format` will automatically format your code correctly.

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
