### PR TITLE
Fix: Include -ms-flexbox value when parsing css display property

### DIFF
--- a/src/css/property-descriptors/display.ts
+++ b/src/css/property-descriptors/display.ts
@@ -63,6 +63,7 @@ const parseDisplayValue = (display: string): Display => {
             return DISPLAY.TABLE;
         case 'flex':
         case '-webkit-flex':
+        case '-ms-flexbox':
             return DISPLAY.FLEX;
         case 'grid':
         case '-ms-grid':


### PR DESCRIPTION
IE10 only supports the [2012 syntax](https://www.w3.org/TR/2012/WD-css3-flexbox-20120322/) of flexbox.
