### PR TITLE
fix(z-index):z-index order

### DIFF
--- a/src/render/stacking-context.ts
+++ b/src/render/stacking-context.ts
@@ -115,7 +115,7 @@ const parseStackTree = (
                 } else if (order > 0) {
                     let index = 0;
                     parentStack.positiveZIndex.some((current, i) => {
-                        if (order > current.element.container.styles.zIndex.order) {
+                        if (order >= current.element.container.styles.zIndex.order) {
                             index = i + 1;
                             return false;
                         } else if (index > 0) {

--- a/tests/reftests/zindex/z-index20.html
+++ b/tests/reftests/zindex/z-index20.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+    <head lang="en">
+        <meta charset="UTF-8" />
+        <title>z-index20</title>
+        <style>
+            .container {
+                width: 375px;
+                height: 603px;
+                background-color: #999;
+                position: relative;
+                margin-bottom: 30px;
+            }
+            .child1 {
+                height: 500px;
+                width: 200px;
+                background-color: red;
+                z-index: 20;
+                position: absolute;
+                left: 0;
+                top: 0;
+            }
+            .child2 {
+                height: 50px;
+                width: 100px;
+                background-color: blue;
+                z-index: 20;
+                position: absolute;
+                left: 30px;
+                top: 30px;
+            }
+        </style>
+        <script type="text/javascript" src="../../test.js"></script>
+    </head>
+    <body>
+        <div class="container" id="___id___">
+            <div class="child1"></div>
+            <div class="child2"></div>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION

**Summary**

Fixed the wrong calculation of the order of layers when the z-index is equal

This PR fixes/implements the following **bugs/features**

* [x] Fixed in case of equal z-index


