### PR TITLE
fix: text-decoration issue

### DIFF
--- a/src/css/index.ts
+++ b/src/css/index.ts
@@ -192,7 +192,10 @@ export class CSSParsedDeclaration {
         this.position = parse(position, declaration.position);
         this.textAlign = parse(textAlign, declaration.textAlign);
         this.textDecorationColor = parse(textDecorationColor, declaration.textDecorationColor || declaration.color);
-        this.textDecorationLine = parse(textDecorationLine, declaration.textDecorationLine);
+        this.textDecorationLine = parse(
+            textDecorationLine,
+            declaration.textDecorationLine || declaration.textDecoration
+        );
         this.textShadow = parse(textShadow, declaration.textShadow);
         this.textTransform = parse(textTransform, declaration.textTransform);
         this.transform = parse(transform, declaration.transform);


### PR DESCRIPTION
this pull request is to  solve issue #2088 

from my debug, on iOS 11.4 and 12.1,   style `text-decoration` value in `declaration.textDecorationLine` is `undefined` or `none`, but can get with `declaration.textDecoration`