### PR TITLE
Remove line about library being experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ The script renders the current page as a canvas image, by reading the DOM and th
 It does **not require any rendering from the server**, as the whole image is created on the **client's browser**. However, as it is heavily dependent on the browser, this library is *not suitable* to be used in nodejs.
 It doesn't magically circumvent any browser content policy restrictions either, so rendering cross-origin content will require a [proxy](https://github.com/niklasvh/html2canvas/wiki/Proxies) to get the content to the [same origin](http://en.wikipedia.org/wiki/Same_origin_policy).
 
-The script is still in a **very experimental state**, so I don't recommend using it in a production environment nor start building applications with it yet, as there will be still major changes made.
-
 ### Browser compatibility ###
 
 The library should work fine on the following browsers (with `Promise` polyfill):


### PR DESCRIPTION
Seeing the number of users of this library and length of time it has been around, I don't think it is necessary to describe it as "experimental" any more.