### PR TITLE
Allow proxy url with parameters

### DIFF
--- a/src/core/cache-storage.ts
+++ b/src/core/cache-storage.ts
@@ -179,7 +179,7 @@ export class Cache {
 
             xhr.onerror = reject;
             const query_string = proxy.indexOf('?') > -1 ? '&' : '?';
-			xhr.open('GET', `${proxy}${query_string}url=${encodeURIComponent(src)}&responseType=${responseType}`);
+            xhr.open('GET', `${proxy}${query_string}url=${encodeURIComponent(src)}&responseType=${responseType}`);
 
             if (responseType !== 'text' && xhr instanceof XMLHttpRequest) {
                 xhr.responseType = responseType;

--- a/src/core/cache-storage.ts
+++ b/src/core/cache-storage.ts
@@ -178,8 +178,8 @@ export class Cache {
             };
 
             xhr.onerror = reject;
-            const query_string = proxy.indexOf('?') > -1 ? '&' : '?';
-            xhr.open('GET', `${proxy}${query_string}url=${encodeURIComponent(src)}&responseType=${responseType}`);
+            const queryString = proxy.indexOf('?') > -1 ? '&' : '?';
+            xhr.open('GET', `${proxy}${queryString}url=${encodeURIComponent(src)}&responseType=${responseType}`);
 
             if (responseType !== 'text' && xhr instanceof XMLHttpRequest) {
                 xhr.responseType = responseType;

--- a/src/core/cache-storage.ts
+++ b/src/core/cache-storage.ts
@@ -178,7 +178,8 @@ export class Cache {
             };
 
             xhr.onerror = reject;
-            xhr.open('GET', `${proxy}?url=${encodeURIComponent(src)}&responseType=${responseType}`);
+            const query_string = proxy.indexOf('?') > -1 ? '&' : '?';
+			xhr.open('GET', `${proxy}${query_string}url=${encodeURIComponent(src)}&responseType=${responseType}`);
 
             if (responseType !== 'text' && xhr instanceof XMLHttpRequest) {
                 xhr.responseType = responseType;


### PR DESCRIPTION
**Summary**
Currently, proxy url's cannot have parameters. 

This PR fixes/implements the following **bugs/features**
2098

Explain the **motivation** for making this change. What existing problem does the pull request solve?

If a proxy url contains a parameter such as:
http://abc.com/myproxy.jsp?myparam=foo
html2canvas will call the proxy using the following url:
http://abc.com/myproxy.jsp?myparam=foo?url=abc.com....
Notice there are two question marks in the url which is incorrect. The second parameter should begin with an ampersand.
The code had automatically put a question mark (?) after the proxy url. I fixed the code to check whether there is already a parameter at the end of the url. This was properly done in the the 0.5 version:

**Test plan (required)**
Pass a proxy url which ends with a parameter(s) as an option.

**Code formatting**

Please make sure that code adheres to the project code formatting. Running `npm run format` will automatically format your code correctly.

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #2098
Closes #2098 
