### PR TITLE
Azure Pipelines: Resolve Chrome Linux build failures

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -88,7 +88,7 @@ module.exports = function(config) {
             base: 'Safari'
         },
         Chrome_Stable: {
-            base: 'Chrome'
+            base: 'ChromeHeadless'
         },
         Firefox_Stable: {
             base: 'Firefox'
@@ -99,7 +99,7 @@ module.exports = function(config) {
 
     const customLaunchers = ciLauncher ? {target_browser: ciLauncher} : {
         stable_chrome: {
-            base: 'Chrome'
+            base: 'ChromeHeadless'
         },
         stable_firefox: {
             base: 'Firefox'


### PR DESCRIPTION
**Summary**
Azure Pipelines builds for `html2canvas` under Chrome on Linux appear to have been failing since late February, and perhaps a little earlier ([ref](https://github.com/niklasvh/html2canvas/pull/2132/checks?check_run_id=475396574)). 

A [recent build log](https://dev.azure.com/niklasvh/html2canvas/_build/results?buildId=256&view=logs&jobId=1ecc60e2-a730-5598-9e07-c12e2a8ba1e2&j=1ecc60e2-a730-5598-9e07-c12e2a8ba1e2&t=442b2b39-a15b-50fe-6fa6-917f1ac11af5) seems to indicate that Chrome has trouble launching, perhaps due to issues connecting to the local X server (display) infrastructure.

```
13 04 2020 21:10:28.427:ERROR [launcher]: Chrome stdout: 
13 04 2020 21:10:28.427:ERROR [launcher]: Chrome stderr: [4250:4250:0413/211026.555114:ERROR:edid_parser.cc(102)] Too short EDID data: manufacturer id
[4250:4297:0413/211026.592660:ERROR:bus.cc(393)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
[4250:4297:0413/211026.611071:ERROR:bus.cc(393)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
[4250:4297:0413/211026.611138:ERROR:bus.cc(393)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
[4294:4294:0413/211026.649850:ERROR:gl_surface_glx.cc(89)] glXGetFBConfigs failed.
```

There are similar [recent reports](https://github.com/Microsoft/WSL/issues/3282#issuecomment-605741288) of failures for Chrome Headless (no-UI) mode.

In order to gain more confidence in pending and future pull requests it would be good to resolve the test failures in `master`, and if necessary ask contributors to pull the fixes.

**Test plan (required)**
This is a little tricky since we can't directly inspect the Linux environment that the builds are taking place on.  But we may be able to experiment with various configuration settings, add more verbose debugging, and if necessary add additional inspection steps to the builds.

This pull request may end up containing a series of experimental commits in order to narrow down the cause and identify a fix.

Note that this pull request **does not** include the build fixes made in #2204 pull request that addresses failures for macOS-derived builds.