### PR TITLE
Azure Pipelines: upgrade from macOS 10.13 -> 10.14

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,6 +90,7 @@ jobs:
       displayName: iOS Simulator Safari 12
       vmImage: 'macOS-10.14'
       targetBrowser: Safari_IOS_12
+      xcodeSelection: '/Applications/Xcode_10.1.app'
 
   - template: ci/browser-tests.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,28 +74,28 @@ jobs:
     parameters:
       name: Browser_Tests_OSX_Safari_IOS_9
       displayName: iOS Simulator Safari 9
-      vmImage: 'macOS-10.13'
+      vmImage: 'macOS-10.14'
       targetBrowser: Safari_IOS_9
 
   - template: ci/browser-tests.yml
     parameters:
       name: Browser_Tests_OSX_Safari_IOS_10
       displayName: iOS Simulator Safari 10
-      vmImage: 'macOS-10.13'
+      vmImage: 'macOS-10.14'
       targetBrowser: Safari_IOS_10
 
   - template: ci/browser-tests.yml
     parameters:
       name: Browser_Tests_OSX_Safari_IOS_12
       displayName: iOS Simulator Safari 12
-      vmImage: 'macOS-10.13'
+      vmImage: 'macOS-10.14'
       targetBrowser: Safari_IOS_12
 
   - template: ci/browser-tests.yml
     parameters:
       name: Browser_Tests_OSX_Safari_Stable
       displayName: OSX Safari Stable
-      vmImage: 'macOS-10.13'
+      vmImage: 'macOS-10.14'
       targetBrowser: Safari_Stable
 
   - template: ci/browser-tests.yml

--- a/ci/browser-tests.yml
+++ b/ci/browser-tests.yml
@@ -31,7 +31,7 @@ jobs:
       inputs:
         artifactName: build
         downloadPath: $(System.DefaultWorkingDirectory)
-    - ${{ if ne(parameters.xcodeSelection, '') }}
+    - ${{ if ne(parameters.xcodeSelection, '') }}:
       - script: xcode-select -s "${{ parameters.xcodeSelection }}"
         displayName: 'Switch Xcode'
     - ${{ if not(eq(parameters.xvfb, 'true')) }}:

--- a/ci/browser-tests.yml
+++ b/ci/browser-tests.yml
@@ -32,7 +32,7 @@ jobs:
         artifactName: build
         downloadPath: $(System.DefaultWorkingDirectory)
     - ${{ if ne(parameters.xcodeSelection, '') }}:
-      - script: xcode-select -s "${{ parameters.xcodeSelection }}"
+      - script: sudo xcode-select -s "${{ parameters.xcodeSelection }}"
         displayName: 'Switch Xcode'
     - ${{ if not(eq(parameters.xvfb, 'true')) }}:
       - script: npm run karma

--- a/ci/browser-tests.yml
+++ b/ci/browser-tests.yml
@@ -32,8 +32,8 @@ jobs:
         artifactName: build
         downloadPath: $(System.DefaultWorkingDirectory)
     - ${{ if ne(parameters.xcodeSelection, '') }}
-      displayName: 'Switch Xcode'
       - script: xcode-select -s "${{ parameters.xcodeSelection }}"
+        displayName: 'Switch Xcode'
     - ${{ if not(eq(parameters.xvfb, 'true')) }}:
       - script: npm run karma
         displayName: 'Run browser tests'

--- a/ci/browser-tests.yml
+++ b/ci/browser-tests.yml
@@ -31,6 +31,9 @@ jobs:
       inputs:
         artifactName: build
         downloadPath: $(System.DefaultWorkingDirectory)
+    - ${{ if ne(parameters.xcodeSelection, '') }}
+      displayName: 'Switch Xcode'
+      - script: xcode-select -s "${{ parameters.xcodeSelection }}"
     - ${{ if not(eq(parameters.xvfb, 'true')) }}:
       - script: npm run karma
         displayName: 'Run browser tests'

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -128,7 +128,7 @@ module.exports = function(config) {
             console.log('starting with url 2 ', url, args);
             simctl.getDevices(args.sdk).then(devices => {
                 console.log('devices: ', devices);
-                const d = devices[args.sdk].find(d => {
+                const d = devices.find(d => {
                     return d.name === args.name;
                 });
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -89,7 +89,7 @@ module.exports = function(config) {
             flags: ['-extoff']
         },
         Safari_Stable: {
-            base: 'Safari'
+            base: 'SafariNative'
         },
         Chrome_Stable: {
             base: 'Chrome'

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,16 +13,19 @@ module.exports = function(config) {
         Safari_IOS_9: {
             base: 'MobileSafari',
             name: 'iPhone 5s',
+            platform: 'iOS',
             sdk: '9.0'
         },
         Safari_IOS_10: {
             base: 'MobileSafari',
             name: 'iPhone 5s',
+            platform: 'iOS',
             sdk: '10.0'
         },
         Safari_IOS_12: {
             base: 'MobileSafari',
             name: 'iPhone 5s',
+            platform: 'iOS',
             sdk: '12.1'
         },
         SauceLabs_IE9: {
@@ -126,7 +129,7 @@ module.exports = function(config) {
         baseBrowserDecorator(this);
         this.on('start', url => {
             console.log('starting with url 2 ', url, args);
-            simctl.getDevices(args.sdk).then(devices => {
+            simctl.getDevices(args.sdk, args.platform).then(devices => {
                 console.log('devices: ', devices);
                 const d = devices.find(d => {
                     return d.name === args.name;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -125,7 +125,9 @@ module.exports = function(config) {
         }
         baseBrowserDecorator(this);
         this.on('start', url => {
+            console.log('starting with url 2 ', url, args);
             simctl.getDevices().then(devices => {
+                console.log('devices: ', devices);
                 const d = devices[args.sdk].find(d => {
                     return d.name === args.name;
                 });
@@ -136,6 +138,7 @@ module.exports = function(config) {
                     this._process.kill();
                     return;
                 }
+
 
                 return iosSimulator.getSimulator(d.udid).then(device => {
                     return simctl.bootDevice(d.udid).then(() => device);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -23,11 +23,11 @@ module.exports = function(config) {
             platform: 'iOS',
             sdk: '10.0'
         },
-        Safari_IOS_12: {
+        Safari_IOS_11: {
             base: 'MobileSafari',
             name: 'iPhone 5s',
             platform: 'iOS',
-            sdk: '12.1'
+            sdk: '11.4'
         },
         SauceLabs_IE9: {
             base: 'SauceLabs',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,6 +4,7 @@
 const path = require('path');
 const simctl = require('node-simctl');
 const iosSimulator = require('appium-ios-simulator');
+const listenAddress = 'localhost';
 const port = 9876;
 
 const log = require('karma/lib/logger').create('launcher:MobileSafari');
@@ -213,6 +214,9 @@ module.exports = function(config) {
         junitReporter: {
             outputDir: 'tmp/junit/'
         },
+
+        // web server listen address,
+        listenAddress,
 
         // web server port
         port,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -129,9 +129,7 @@ module.exports = function(config) {
         }
         baseBrowserDecorator(this);
         this.on('start', url => {
-            console.log('starting with url 2 ', url, args);
             simctl.getDevices(args.sdk, args.platform).then(devices => {
-                console.log('devices: ', devices);
                 const d = devices.find(d => {
                     return d.name === args.name;
                 });
@@ -142,7 +140,6 @@ module.exports = function(config) {
                     this._process.kill();
                     return;
                 }
-
 
                 return iosSimulator.getSimulator(d.udid).then(device => {
                     return simctl.bootDevice(d.udid).then(() => device);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -126,7 +126,7 @@ module.exports = function(config) {
         baseBrowserDecorator(this);
         this.on('start', url => {
             console.log('starting with url 2 ', url, args);
-            simctl.getDevices().then(devices => {
+            simctl.getDevices(args.sdk).then(devices => {
                 console.log('devices: ', devices);
                 const d = devices[args.sdk].find(d => {
                     return d.name === args.name;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -23,11 +23,11 @@ module.exports = function(config) {
             platform: 'iOS',
             sdk: '10.0'
         },
-        Safari_IOS_11: {
+        Safari_IOS_12: {
             base: 'MobileSafari',
             name: 'iPhone 5s',
             platform: 'iOS',
-            sdk: '11.4'
+            sdk: '12.1'
         },
         SauceLabs_IE9: {
             base: 'SauceLabs',

--- a/package-lock.json
+++ b/package-lock.json
@@ -11163,10 +11163,10 @@
         }
       }
     },
-    "karma-safari-launcher": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/karma-safari-launcher/-/karma-safari-launcher-1.0.0.tgz",
-      "integrity": "sha1-lpgqLMR9BmquccVTursoMZEVos4=",
+    "karma-safarinative-launcher": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/karma-safarinative-launcher/-/karma-safarinative-launcher-1.1.0.tgz",
+      "integrity": "sha512-vdMjdQDHkSUbOZc8Zq2K5bBC0yJGFEgfrKRJTqt0Um0SC1Rt8drS2wcN6UA3h4LgsL3f1pMcmRSvKucbJE8Qdg==",
       "dev": true
     },
     "karma-sauce-launcher": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1528,6 +1528,50 @@
         "core-js": "^2.5.7"
       }
     },
+    "@jimp/plugin-circle": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.9.8.tgz",
+      "integrity": "sha512-+UStXUPCzPqzTixLC8eVqcFcEa6TS+BEM/6/hyM11TDb9sbiMGeUtgpwZP/euR5H5gfpAQDA1Ppzqhh5fuMDlw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@jimp/utils": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.9.8.tgz",
+          "integrity": "sha512-UK0Fu0eevQlpRXq5ff4o/71HJlpX9wJMddJjMYg9vUqCCl8ZnumRAljfShHFhGyO+Vc9IzN6dd8Y5JZZTp1KOw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "core-js": "^3.4.1"
+          }
+        },
+        "core-js": {
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "dev": true
+        }
+      }
+    },
     "@jimp/plugin-color": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.6.0.tgz",
@@ -1587,6 +1631,50 @@
       "requires": {
         "@jimp/utils": "^0.6.0",
         "core-js": "^2.5.7"
+      }
+    },
+    "@jimp/plugin-fisheye": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.9.8.tgz",
+      "integrity": "sha512-VnsalrD05f4pxG1msjnkwIFi5QveOqRm4y7VkoZKNX+iqs4TvRnH5+HpBnfdMzX/RXBi+Lf/kpTtuZgbOu/QWw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@jimp/utils": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.9.8.tgz",
+          "integrity": "sha512-UK0Fu0eevQlpRXq5ff4o/71HJlpX9wJMddJjMYg9vUqCCl8ZnumRAljfShHFhGyO+Vc9IzN6dd8Y5JZZTp1KOw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "core-js": "^3.4.1"
+          }
+        },
+        "core-js": {
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "dev": true
+        }
       }
     },
     "@jimp/plugin-flip": {
@@ -1678,6 +1766,94 @@
       "requires": {
         "@jimp/utils": "^0.6.0",
         "core-js": "^2.5.7"
+      }
+    },
+    "@jimp/plugin-shadow": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.9.8.tgz",
+      "integrity": "sha512-t/pE+QS3r1ZUxGIQNmwWDI3c5+/hLU+gxXD+C3EEC47/qk3gTBHpj/xDdGQBoObdT/HRjR048vC2BgBfzjj2hg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@jimp/utils": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.9.8.tgz",
+          "integrity": "sha512-UK0Fu0eevQlpRXq5ff4o/71HJlpX9wJMddJjMYg9vUqCCl8ZnumRAljfShHFhGyO+Vc9IzN6dd8Y5JZZTp1KOw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "core-js": "^3.4.1"
+          }
+        },
+        "core-js": {
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "dev": true
+        }
+      }
+    },
+    "@jimp/plugin-threshold": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.9.8.tgz",
+      "integrity": "sha512-WWmC3lnIwOTPvkKu55w4DUY8Ehlzf3nU98bY0QtIzkqxkAOZU5m+lvgC/JxO5FyGiA57j9FLMIf0LsWkjARj7g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@jimp/utils": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.9.8.tgz",
+          "integrity": "sha512-UK0Fu0eevQlpRXq5ff4o/71HJlpX9wJMddJjMYg9vUqCCl8ZnumRAljfShHFhGyO+Vc9IzN6dd8Y5JZZTp1KOw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "core-js": "^3.4.1"
+          }
+        },
+        "core-js": {
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "dev": true
+        }
       }
     },
     "@jimp/plugins": {
@@ -3374,6 +3550,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
       "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+      "dev": true
+    },
+    "base64-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base64-stream/-/base64-stream-1.0.0.tgz",
+      "integrity": "sha512-BQQZftaO48FcE1Kof9CmXMFaAdqkcNorgc8CxesZv9nMbbTF1EFyQe89UOuh//QMmdtfUDXyO8rgUalemL5ODA==",
       "dev": true
     },
     "base64id": {
@@ -11016,6 +11198,15 @@
         "is-buffer": "^1.1.5"
       }
     },
+    "klaw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -11159,6 +11350,30 @@
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+      "dev": true
+    },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+      "dev": true
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -11194,6 +11409,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
       "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
+      "dev": true
+    },
+    "lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
       "dev": true
     },
     "log-symbols": {
@@ -11945,6 +12166,12 @@
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "dev": true
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -12293,18 +12520,1025 @@
       }
     },
     "node-simctl": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/node-simctl/-/node-simctl-5.0.0.tgz",
-      "integrity": "sha512-yHCCIP81WTvcul9qL5t/evk/eKIBtQ0kGdDfU+rkPQVLm8Wavy2g2NV5p1DqVm1ZBWRTvH2x+2b0Nwezim7klg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/node-simctl/-/node-simctl-5.3.0.tgz",
+      "integrity": "sha512-5EJPsorg+ZLxeLk6Cc5Q3hI4WcWkWSWkqQnJEJf3DrM9UekGvpgOUE8uZtr8dTtY/GZCsI30Ksusqm+zGq3NsA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "appium-support": "^2.26.0",
-        "appium-xcode": "^3.1.0",
+        "appium-support": "^2.37.0",
+        "appium-xcode": "^3.8.0",
         "asyncbox": "^2.3.1",
         "lodash": "^4.2.1",
+        "semver": "^7.0.0",
         "source-map-support": "^0.5.5",
         "teen_process": "^1.5.1"
+      },
+      "dependencies": {
+        "@jimp/bmp": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.9.8.tgz",
+          "integrity": "sha512-CZYQPEC3iUBMuaGWrtIG+GKNl93q/PkdudrCKJR/B96dfNngsmoosEm3LuFgJHEcJIfvnJkNqKw74l+zEiqCbg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "bmp-js": "^0.1.0",
+            "core-js": "^3.4.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/core": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.9.8.tgz",
+          "integrity": "sha512-N4GCjcXb0QwR5GBABDK2xQ3cKyaF7LlCYeJEG9mV7G/ynBoRqJe4JA6YKU9Ww9imGkci/4A594nQo8tUIqdcBw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "any-base": "^1.1.0",
+            "buffer": "^5.2.0",
+            "core-js": "^3.4.1",
+            "exif-parser": "^0.1.12",
+            "file-type": "^9.0.0",
+            "load-bmfont": "^1.3.1",
+            "mkdirp": "^0.5.1",
+            "phin": "^2.9.1",
+            "pixelmatch": "^4.0.2",
+            "tinycolor2": "^1.4.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.5",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+              "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+              "dev": true,
+              "requires": {
+                "minimist": "^1.2.5"
+              }
+            }
+          }
+        },
+        "@jimp/custom": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.9.8.tgz",
+          "integrity": "sha512-1UpJjI7fhX02BWLJ/KEqPwkHH60eNkCNeD6hEd+IZdTwLXfZCfFiM5BVlpgiZYZJSsVoRiAL4ne2Q5mCiKPKyw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/core": "^0.9.8",
+            "core-js": "^3.4.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/gif": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.9.8.tgz",
+          "integrity": "sha512-LEbfpcO1sBJIQCJHchZjNlyNxzPjZQQ4X32klpQHZJG58n9FvL7Uuh1rpkrJRbqv3cU3P0ENNtTrsBDxsYwcfA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "core-js": "^3.4.1",
+            "omggif": "^1.0.9"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/jpeg": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.9.8.tgz",
+          "integrity": "sha512-5u29SUzbZ32ZMmOaz3gO0hXatwSCnsvEAXRCKZoPPgbsPoyFAiZKVxjfLzjkeQF6awkvJ8hZni5chM15SNMg+g==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "core-js": "^3.4.1",
+            "jpeg-js": "^0.3.4"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/plugin-blit": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.9.8.tgz",
+          "integrity": "sha512-6xTDomxJybhBcby1IUVaPydZFhxf+V0DRgfDlVK81kR9kSCoshJpzWqDuWrMqjNEPspPE7jRQwHMs0FdU7mVwQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "core-js": "^3.4.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/plugin-blur": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.9.8.tgz",
+          "integrity": "sha512-dqbxuNFBRbmt35iIRacdgma7nlXklmPThsKcGWNTDmqb/hniK5IC+0xSPzBV4qMI2fLGP39LWHqqDZ0xDz14dA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "core-js": "^3.4.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/plugin-color": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.9.8.tgz",
+          "integrity": "sha512-SDHxOQsJHpt75hk6+sSlCPc2B3UJlXosFW+iLZ11xX1Qr0IdDtbfYlIoPmjKQFIDUNzqLSue/z7sKQ1OMZr/QA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "core-js": "^3.4.1",
+            "tinycolor2": "^1.4.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/plugin-contain": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.9.8.tgz",
+          "integrity": "sha512-oK52CPt7efozuLYCML7qOmpFeDt3zpU8qq8UZlnjsDs15reU6L8EiUbwYpJvzoEnEOh1ZqamB8F/gymViEO5og==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "core-js": "^3.4.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/plugin-cover": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.9.8.tgz",
+          "integrity": "sha512-nnamtHzMrNd5j5HRSPd1VzpZ8v9YYtUJPtvCdHOOiIjqG72jxJ2kTBlsS3oG5XS64h/2MJwpl/fmmMs1Tj1CmQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "core-js": "^3.4.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/plugin-crop": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.9.8.tgz",
+          "integrity": "sha512-Nv/6AIp4aJmbSIH2uiIqm+kSoShKM8eaX2fyrUTj811kio0hwD3f/vIxrWebvAqwDZjAFIAmMufFoFCVg6caoQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "core-js": "^3.4.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/plugin-displace": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.9.8.tgz",
+          "integrity": "sha512-0OgPjkOVa2xdbqI8P6gBKX/UK36RbaYVrFyXL8Jy9oNF69+LYWyTskuCu9YbGxzlCVjY/JFqQOvrKDbxgMYAKA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "core-js": "^3.4.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/plugin-dither": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.9.8.tgz",
+          "integrity": "sha512-jGM/4ByniZJnmV2fv8hKwyyydXZe/YzvgBcnB8XxzCq8kVR3Imcn+qnd2PEPZzIPKOTH4Cig/zo9Vk9Bs+m5FQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "core-js": "^3.4.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/plugin-flip": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.9.8.tgz",
+          "integrity": "sha512-XbiZ4OfHD6woc0f6Sk7XxB6a7IyMjTRQ4pNU7APjaNxsl3L6qZC8qfCQphWVe3DHx7f3y7jEiPMvNnqRDP1xgA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "core-js": "^3.4.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/plugin-gaussian": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.9.8.tgz",
+          "integrity": "sha512-ZBl5RA6+4XAD+mtqLfiG7u+qd8W5yqq3RBNca8eFqUSVo1v+eB2tzeLel0CWfVC/z6cw93Awm/nVnm6/CL2Oew==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "core-js": "^3.4.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/plugin-invert": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.9.8.tgz",
+          "integrity": "sha512-ESploqCoF6qUv5IWhVLaO5fEcrYZEsAWPFflh6ROiD2mmFKQxfeK+vHnk3IDLHtUwWTkAZQNbk89BVq7xvaNpQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "core-js": "^3.4.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/plugin-mask": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.9.8.tgz",
+          "integrity": "sha512-zSvEisTV4iGsBReitEdnQuGJq9/1xB5mPATadYZmIlp8r5HpD72HQb0WdEtb51/pu9Odt8KAxUf0ASg/PRVUiQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "core-js": "^3.4.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/plugin-normalize": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.9.8.tgz",
+          "integrity": "sha512-dPFBfwTa67K1tRw1leCidQT25R3ozrTUUOpO4jcGFHqXvBTWaR8sML1qxdfOBWs164mE5YpfdTvu6MM/junvCg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "core-js": "^3.4.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/plugin-print": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.9.8.tgz",
+          "integrity": "sha512-nLLPv1/faehRsOjecXXUb6kzhRcZzImO55XuFZ0c90ZyoiHm4UFREwO5sKxHGvpLXS6RnkhvSav4+IWD2qGbEQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "core-js": "^3.4.1",
+            "load-bmfont": "^1.4.0"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/plugin-resize": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.9.8.tgz",
+          "integrity": "sha512-L80NZ+HKsiKFyeDc6AfneC4+5XACrdL2vnyAVfAAsb3pmamgT/jDInWvvGhyI0Y76vx2w6XikplzEznW/QQvWg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "core-js": "^3.4.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/plugin-rotate": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.9.8.tgz",
+          "integrity": "sha512-bpqzQheISYnBXKyU1lIj46uR7mRs0UhgEREWK70HnvFJSlRshdcoNMIrKamyrJeFdJrkYPSfR/a6D0d5zsWf1Q==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "core-js": "^3.4.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/plugin-scale": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.9.8.tgz",
+          "integrity": "sha512-QU3ZS4Lre8nN66U9dKCOC4FNfaOh/QJFYUmQPKpPS924oYbtnm4OlmsdfpK2hVMSVVyVOis8M+xpA1rDBnIp7w==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "core-js": "^3.4.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/plugins": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.9.8.tgz",
+          "integrity": "sha512-tD+cxS9SuEZaQ1hhAkNKw9TkUAqfoBAhdWPBrEZDr/GvGPrvJR4pYmmpSYhc5IZmMbXfQayHTTGqjj8D18bToA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/plugin-blit": "^0.9.8",
+            "@jimp/plugin-blur": "^0.9.8",
+            "@jimp/plugin-circle": "^0.9.8",
+            "@jimp/plugin-color": "^0.9.8",
+            "@jimp/plugin-contain": "^0.9.8",
+            "@jimp/plugin-cover": "^0.9.8",
+            "@jimp/plugin-crop": "^0.9.8",
+            "@jimp/plugin-displace": "^0.9.8",
+            "@jimp/plugin-dither": "^0.9.8",
+            "@jimp/plugin-fisheye": "^0.9.8",
+            "@jimp/plugin-flip": "^0.9.8",
+            "@jimp/plugin-gaussian": "^0.9.8",
+            "@jimp/plugin-invert": "^0.9.8",
+            "@jimp/plugin-mask": "^0.9.8",
+            "@jimp/plugin-normalize": "^0.9.8",
+            "@jimp/plugin-print": "^0.9.8",
+            "@jimp/plugin-resize": "^0.9.8",
+            "@jimp/plugin-rotate": "^0.9.8",
+            "@jimp/plugin-scale": "^0.9.8",
+            "@jimp/plugin-shadow": "^0.9.8",
+            "@jimp/plugin-threshold": "^0.9.8",
+            "core-js": "^3.4.1",
+            "timm": "^1.6.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/png": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.9.8.tgz",
+          "integrity": "sha512-9CqR8d40zQCDhbnXHqcwkAMnvlV0vk9xSyE6LHjkYHS7x18Unsz5txQdsaEkEcXxCrOQSoWyITfLezlrWXRJAA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.9.8",
+            "core-js": "^3.4.1",
+            "pngjs": "^3.3.3"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/tiff": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.9.8.tgz",
+          "integrity": "sha512-eMxcpJivJqMByn2dZxUHLeh6qvVs5J/52kBF3TFa3C922OJ97D9l1C1h0WKUCBqFMWzMYapQQ4vwnLgpJ5tkow==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "core-js": "^3.4.1",
+            "utif": "^2.0.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/types": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.9.8.tgz",
+          "integrity": "sha512-H5y/uqt0lqJ/ZN8pWqFG+pv8jPAppMKkTMByuC8YBIjWSsornwv44hjiWl93sbYhduLZY8ubz/CbX9jH2X6EwA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/bmp": "^0.9.8",
+            "@jimp/gif": "^0.9.8",
+            "@jimp/jpeg": "^0.9.8",
+            "@jimp/png": "^0.9.8",
+            "@jimp/tiff": "^0.9.8",
+            "core-js": "^3.4.1",
+            "timm": "^1.6.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@jimp/utils": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.9.8.tgz",
+          "integrity": "sha512-UK0Fu0eevQlpRXq5ff4o/71HJlpX9wJMddJjMYg9vUqCCl8ZnumRAljfShHFhGyO+Vc9IzN6dd8Y5JZZTp1KOw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "core-js": "^3.4.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "appium-support": {
+          "version": "2.43.0",
+          "resolved": "https://registry.npmjs.org/appium-support/-/appium-support-2.43.0.tgz",
+          "integrity": "sha512-HELlIM6J0CI/ALHKbr8Z8TNjrnyw1QVdzLKCUX/l4Gw/MmaS4QvHNpuy3Bdd0MCxX/aw76q2F58HmCiwzHtAkg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "archiver": "^3.1.1",
+            "base64-stream": "^1.0.0",
+            "bluebird": "^3.5.1",
+            "bplist-creator": "^0",
+            "bplist-parser": "^0.2",
+            "extract-zip": "^1.6.0",
+            "glob": "^7.1.2",
+            "jimp": "^0.9.0",
+            "jsftp": "^2.1.2",
+            "klaw": "^3.0.0",
+            "lodash": "^4.2.1",
+            "md5-file": "^4.0.0",
+            "mjpeg-server": "^0.3.0",
+            "mkdirp": "^1.0.0",
+            "moment": "^2.24.0",
+            "mv": "^2.1.1",
+            "ncp": "^2.0.0",
+            "npmlog": "^4.1.2",
+            "plist": "^3.0.1",
+            "pluralize": "^8.0.0",
+            "pngjs": "^3.0.0",
+            "request": "^2.83.0",
+            "request-promise": "^4.2.2",
+            "rimraf": "^3.0.0",
+            "sanitize-filename": "^1.6.1",
+            "semver": "^7.0.0",
+            "shell-quote": "^1.7.2",
+            "source-map-support": "^0.5.5",
+            "teen_process": "^1.5.1",
+            "uuid": "^7.0.2",
+            "which": "^2.0.0",
+            "yauzl": "^2.7.0"
+          }
+        },
+        "appium-xcode": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/appium-xcode/-/appium-xcode-3.10.0.tgz",
+          "integrity": "sha512-6Db49w2UjcdMn96nUMS/EGKE/6r/sgIPcw8mr9+e4Oeb5rvROAm/VeIWmwnov3uk2JG3SGkLTQRB9tROKKRDgw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "appium-support": "^2.4.0",
+            "asyncbox": "^2.3.0",
+            "lodash": "^4.17.4",
+            "plist": "^3.0.1",
+            "semver": "^7.0.0",
+            "source-map-support": "^0.5.5",
+            "teen_process": "^1.3.0"
+          }
+        },
+        "archiver": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
+          "integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
+          "dev": true,
+          "requires": {
+            "archiver-utils": "^2.1.0",
+            "async": "^2.6.3",
+            "buffer-crc32": "^0.2.1",
+            "glob": "^7.1.4",
+            "readable-stream": "^3.4.0",
+            "tar-stream": "^2.1.0",
+            "zip-stream": "^2.1.2"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.1.6",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+              "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            }
+          }
+        },
+        "archiver-utils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+          "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.2.0",
+            "lazystream": "^1.0.0",
+            "lodash.defaults": "^4.2.0",
+            "lodash.difference": "^4.5.0",
+            "lodash.flatten": "^4.4.0",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.union": "^4.6.0",
+            "normalize-path": "^3.0.0",
+            "readable-stream": "^2.0.0"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.1.6",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+              "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            }
+          }
+        },
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "big-integer": {
+          "version": "1.6.48",
+          "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+          "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+          "dev": true
+        },
+        "bl": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+          "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+              "dev": true
+            }
+          }
+        },
+        "bplist-parser": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+          "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+          "dev": true,
+          "requires": {
+            "big-integer": "^1.6.44"
+          }
+        },
+        "buffer": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "compress-commons": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
+          "integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
+          "dev": true,
+          "requires": {
+            "buffer-crc32": "^0.2.13",
+            "crc32-stream": "^3.0.1",
+            "normalize-path": "^3.0.0",
+            "readable-stream": "^2.3.6"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            }
+          }
+        },
+        "core-js": {
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+          "dev": true
+        },
+        "crc32-stream": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
+          "integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
+          "dev": true,
+          "requires": {
+            "crc": "^3.4.4",
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+          "dev": true
+        },
+        "jimp": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.9.8.tgz",
+          "integrity": "sha512-DHN4apKMwLIvD/TKO9tFfPuankNuVK98vCwHm/Jv9z5cJnrd38xhi+4I7IAGmDU3jIDlrEVhzTkFH1Ymv5yTQQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/custom": "^0.9.8",
+            "@jimp/plugins": "^0.9.8",
+            "@jimp/types": "^0.9.8",
+            "core-js": "^3.4.1",
+            "regenerator-runtime": "^0.13.3"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.9.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+              "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.0.tgz",
+          "integrity": "sha512-uyvgU/igkrMgNHwLgXvlpD9jEADbJhB0+JXSywoO47JgJ6c16iau9F9cjtc/E5o0PoqRYTiTIAPRKaYe84z6eQ==",
+          "dev": true
+        },
+        "shell-quote": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+          "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+          "dev": true
+        },
+        "tar-stream": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
+          "integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
+          "dev": true,
+          "requires": {
+            "bl": "^4.0.1",
+            "end-of-stream": "^1.4.1",
+            "fs-constants": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1"
+          }
+        },
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "zip-stream": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.3.tgz",
+          "integrity": "sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==",
+          "dev": true,
+          "requires": {
+            "archiver-utils": "^2.1.0",
+            "compress-commons": "^2.1.1",
+            "readable-stream": "^3.4.0"
+          }
+        }
       }
     },
     "normalize-package-data": {
@@ -12979,6 +14213,12 @@
           "dev": true
         }
       }
+    },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true
     },
     "pn": {
       "version": "1.1.0",
@@ -13948,6 +15188,15 @@
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
+      }
+    },
+    "sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "dev": true,
+      "requires": {
+        "truncate-utf8-bytes": "^1.0.0"
       }
     },
     "sauce-connect-launcher": {
@@ -15773,6 +17022,15 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "dev": true,
+      "requires": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
     "ts-jest": {
       "version": "24.1.0",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.1.0.tgz",
@@ -16206,6 +17464,12 @@
         "lru-cache": "4.1.x",
         "tmp": "0.0.x"
       }
+    },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
+      "dev": true
     },
     "utif": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "karma-ie-launcher": "^1.0.0",
     "karma-junit-reporter": "^1.2.0",
     "karma-mocha": "^1.3.0",
-    "karma-safari-launcher": "^1.0.0",
+    "karma-safarinative-launcher": "^1.1.0",
     "karma-sauce-launcher": "^2.0.2",
     "mocha": "^6.1.4",
     "node-simctl": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "karma-safari-launcher": "^1.0.0",
     "karma-sauce-launcher": "^2.0.2",
     "mocha": "^6.1.4",
-    "node-simctl": "^5.0.0",
+    "node-simctl": "^5.3.0",
     "platform": "1.3.4",
     "prettier": "1.17.0",
     "replace-in-file": "^3.0.0",


### PR DESCRIPTION
**Summary**
As per a recent Microsoft's Azure DevOps [blog post](https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/), build images for `macOS 10.13` now [appear to have been removed](https://dev.azure.com/niklasvh/html2canvas/_build/results?buildId=257&view=logs&j=2d670fa7-f2eb-599e-bd33-f0da06e227c7) from Azure Pipelines.

```
##[warning]An image label with the label macOS-10.13 does not exist.
,##[error]The remote provider was unable to process the request.
```

This is causing macOS-related builds to fail.

This pull requests updates the base image for those builds to the more recent `macOS-10.14`.

**Test plan (required)**
The result of Azure Pipeline builds on this pull request for macOS-derived test suites should indicate whether the change is successful.

Note that this pull request **does not** include the build fixes made in #2203 pull request that addresses failures for Chrome on Linux.