### PR TITLE
Concatenate contiguous font-family tokens

### DIFF
--- a/src/css/property-descriptors/__tests__/font-family.ts
+++ b/src/css/property-descriptors/__tests__/font-family.ts
@@ -1,0 +1,25 @@
+import {deepEqual} from 'assert';
+import {Parser} from '../../syntax/parser';
+import {fontFamily} from '../font-family';
+
+const fontFamilyParse = (value: string) => fontFamily.parse(Parser.parseValues(value));
+
+describe('property-descriptors', () => {
+    describe('font-family', () => {
+        it('sans-serif', () =>
+            deepEqual(fontFamilyParse('sans-serif'), [
+                "'sans-serif'",
+            ]));
+
+        it('great fonts 40 library', () =>
+            deepEqual(fontFamilyParse('great fonts 40 library'), [
+                "'great fonts 40 library'",
+            ]));
+
+        it('preferred font, "quoted fallback font"', () =>
+            deepEqual(fontFamilyParse('preferred font, "quoted fallback font"'), [
+                "'preferred font'",
+                "'quoted fallback font'"
+            ]));
+    });
+});

--- a/src/css/property-descriptors/__tests__/font-family.ts
+++ b/src/css/property-descriptors/__tests__/font-family.ts
@@ -21,5 +21,10 @@ describe('property-descriptors', () => {
                 "'preferred font'",
                 "'quoted fallback font'"
             ]));
+
+        it("'escaping test\\'s font'", () =>
+            deepEqual(fontFamilyParse("'escaping test\\'s font'"), [
+                "'escaping test\'s font'",
+            ]));
     });
 });

--- a/src/css/property-descriptors/__tests__/font-family.ts
+++ b/src/css/property-descriptors/__tests__/font-family.ts
@@ -8,7 +8,7 @@ describe('property-descriptors', () => {
     describe('font-family', () => {
         it('sans-serif', () =>
             deepEqual(fontFamilyParse('sans-serif'), [
-                "'sans-serif'",
+                "sans-serif",
             ]));
 
         it('great fonts 40 library', () =>
@@ -16,10 +16,11 @@ describe('property-descriptors', () => {
                 "'great fonts 40 library'",
             ]));
 
-        it('preferred font, "quoted fallback font"', () =>
-            deepEqual(fontFamilyParse('preferred font, "quoted fallback font"'), [
+        it('preferred font, "quoted fallback font", font', () =>
+            deepEqual(fontFamilyParse('preferred font, "quoted fallback font", font'), [
                 "'preferred font'",
-                "'quoted fallback font'"
+                "'quoted fallback font'",
+                "font"
             ]));
 
         it("'escaping test\\'s font'", () =>

--- a/src/css/property-descriptors/__tests__/font-family.ts
+++ b/src/css/property-descriptors/__tests__/font-family.ts
@@ -8,18 +8,18 @@ describe('property-descriptors', () => {
     describe('font-family', () => {
         it('sans-serif', () =>
             deepEqual(fontFamilyParse('sans-serif'), [
-                "sans-serif",
+                "'sans-serif'",
             ]));
 
         it('great fonts 40 library', () =>
             deepEqual(fontFamilyParse('great fonts 40 library'), [
-                "great fonts 40 library",
+                "'great fonts 40 library'",
             ]));
 
         it('preferred font, "quoted fallback font"', () =>
             deepEqual(fontFamilyParse('preferred font, "quoted fallback font"'), [
-                "preferred font",
-                "quoted fallback font"
+                "'preferred font'",
+                "'quoted fallback font'"
             ]));
     });
 });

--- a/src/css/property-descriptors/__tests__/font-family.ts
+++ b/src/css/property-descriptors/__tests__/font-family.ts
@@ -8,18 +8,18 @@ describe('property-descriptors', () => {
     describe('font-family', () => {
         it('sans-serif', () =>
             deepEqual(fontFamilyParse('sans-serif'), [
-                "'sans-serif'",
+                "sans-serif",
             ]));
 
         it('great fonts 40 library', () =>
             deepEqual(fontFamilyParse('great fonts 40 library'), [
-                "'great fonts 40 library'",
+                "great fonts 40 library",
             ]));
 
         it('preferred font, "quoted fallback font"', () =>
             deepEqual(fontFamilyParse('preferred font, "quoted fallback font"'), [
-                "'preferred font'",
-                "'quoted fallback font'"
+                "preferred font",
+                "quoted fallback font"
             ]));
     });
 });

--- a/src/css/property-descriptors/font-family.ts
+++ b/src/css/property-descriptors/font-family.ts
@@ -1,5 +1,5 @@
 import {IPropertyListDescriptor, PropertyDescriptorParsingType} from '../IPropertyDescriptor';
-import {CSSValue, isIdentToken, isNumberToken, isStringToken} from '../syntax/parser';
+import {CSSValue} from '../syntax/parser';
 import {TokenType} from '../syntax/tokenizer';
 
 export type FONT_FAMILY = string;
@@ -15,15 +15,18 @@ export const fontFamily: IPropertyListDescriptor<FontFamily> = {
         const accumulator: string[] = [];
         const results: string[] = [];
         tokens.forEach(token => {
-            if (isIdentToken(token) || isStringToken(token)) {
-                accumulator.push(token.value);
-            }
-            if (isNumberToken(token)) {
-                accumulator.push(token.number.toString());
-            }
-            if (token.type === TokenType.COMMA_TOKEN) {
-                results.push(`'${accumulator.join(' ')}'`);
-                accumulator.length = 0;
+            switch (token.type) {
+                case TokenType.IDENT_TOKEN:
+                case TokenType.STRING_TOKEN:
+                    accumulator.push(token.value);
+                    break;
+                case TokenType.NUMBER_TOKEN:
+                    accumulator.push(token.number.toString());
+                    break;
+                case TokenType.COMMA_TOKEN:
+                    results.push(`'${accumulator.join(' ')}'`);
+                    accumulator.length = 0;
+                    break;
             }
         });
         if (accumulator.length) {

--- a/src/css/property-descriptors/font-family.ts
+++ b/src/css/property-descriptors/font-family.ts
@@ -24,13 +24,13 @@ export const fontFamily: IPropertyListDescriptor<FontFamily> = {
                     accumulator.push(token.number.toString());
                     break;
                 case TokenType.COMMA_TOKEN:
-                    results.push(`'${accumulator.join(' ')}'`);
+                    results.push(accumulator.join(' '));
                     accumulator.length = 0;
                     break;
             }
         });
         if (accumulator.length) {
-            results.push(`'${accumulator.join(' ')}'`);
+            results.push(accumulator.join(' '));
         }
         return results;
     }

--- a/src/css/property-descriptors/font-family.ts
+++ b/src/css/property-descriptors/font-family.ts
@@ -12,7 +12,22 @@ export const fontFamily: IPropertyListDescriptor<FontFamily> = {
     prefix: false,
     type: PropertyDescriptorParsingType.LIST,
     parse: (tokens: CSSValue[]) => {
-        return tokens.filter(isStringToken).map(token => token.value);
+        const accumulator: string[] = [];
+        const results: string[] = [];
+        tokens.forEach(token => {
+          if (isStringToken(token)) {
+            accumulator.push(token.value);
+          }
+          if (token.type === TokenType.COMMA_TOKEN) {
+            results.push(accumulator.join(' '));
+            accumulator.length = 0;
+          }
+        });
+        if (accumulator.length) {
+          results.push(accumulator.join(' '));
+        }
+        console.log(results);
+        return results;
     }
 };
 

--- a/src/css/property-descriptors/font-family.ts
+++ b/src/css/property-descriptors/font-family.ts
@@ -26,7 +26,6 @@ export const fontFamily: IPropertyListDescriptor<FontFamily> = {
         if (accumulator.length) {
             results.push(`'${accumulator.join(' ')}'`);
         }
-        console.log(results);
         return results;
     }
 };

--- a/src/css/property-descriptors/font-family.ts
+++ b/src/css/property-descriptors/font-family.ts
@@ -19,12 +19,12 @@ export const fontFamily: IPropertyListDescriptor<FontFamily> = {
             accumulator.push(token.value);
           }
           if (token.type === TokenType.COMMA_TOKEN) {
-            results.push(accumulator.join(' '));
+            results.push(`'${accumulator.join(' ')}'`);
             accumulator.length = 0;
           }
         });
         if (accumulator.length) {
-          results.push(accumulator.join(' '));
+          results.push(`'${accumulator.join(' ')}'`);
         }
         console.log(results);
         return results;

--- a/src/css/property-descriptors/font-family.ts
+++ b/src/css/property-descriptors/font-family.ts
@@ -24,14 +24,14 @@ export const fontFamily: IPropertyListDescriptor<FontFamily> = {
                     accumulator.push(token.number.toString());
                     break;
                 case TokenType.COMMA_TOKEN:
-                    results.push(`'${accumulator.join(' ')}'`);
+                    results.push(accumulator.join(' '));
                     accumulator.length = 0;
                     break;
             }
         });
         if (accumulator.length) {
-            results.push(`'${accumulator.join(' ')}'`);
+            results.push(accumulator.join(' '));
         }
-        return results;
+        return results.map(result => result.includes(' ') ? `'${result}'` : result);
     }
 };

--- a/src/css/property-descriptors/font-family.ts
+++ b/src/css/property-descriptors/font-family.ts
@@ -24,13 +24,13 @@ export const fontFamily: IPropertyListDescriptor<FontFamily> = {
                     accumulator.push(token.number.toString());
                     break;
                 case TokenType.COMMA_TOKEN:
-                    results.push(accumulator.join(' '));
+                    results.push(`'${accumulator.join(' ')}'`);
                     accumulator.length = 0;
                     break;
             }
         });
         if (accumulator.length) {
-            results.push(accumulator.join(' '));
+            results.push(`'${accumulator.join(' ')}'`);
         }
         return results;
     }

--- a/src/css/property-descriptors/font-family.ts
+++ b/src/css/property-descriptors/font-family.ts
@@ -1,6 +1,6 @@
 import {IPropertyListDescriptor, PropertyDescriptorParsingType} from '../IPropertyDescriptor';
-import {CSSValue} from '../syntax/parser';
-import {StringValueToken, TokenType} from '../syntax/tokenizer';
+import {CSSValue, isIdentToken, isStringToken} from '../syntax/parser';
+import {TokenType} from '../syntax/tokenizer';
 
 export type FONT_FAMILY = string;
 
@@ -15,7 +15,7 @@ export const fontFamily: IPropertyListDescriptor<FontFamily> = {
         const accumulator: string[] = [];
         const results: string[] = [];
         tokens.forEach(token => {
-            if (isStringToken(token)) {
+            if (isIdentToken(token) || isStringToken(token)) {
                 accumulator.push(token.value);
             }
             if (token.type === TokenType.COMMA_TOKEN) {
@@ -29,6 +29,3 @@ export const fontFamily: IPropertyListDescriptor<FontFamily> = {
         return results;
     }
 };
-
-const isStringToken = (token: CSSValue): token is StringValueToken =>
-    token.type === TokenType.STRING_TOKEN || token.type === TokenType.IDENT_TOKEN;

--- a/src/css/property-descriptors/font-family.ts
+++ b/src/css/property-descriptors/font-family.ts
@@ -15,16 +15,16 @@ export const fontFamily: IPropertyListDescriptor<FontFamily> = {
         const accumulator: string[] = [];
         const results: string[] = [];
         tokens.forEach(token => {
-          if (isStringToken(token)) {
-            accumulator.push(token.value);
-          }
-          if (token.type === TokenType.COMMA_TOKEN) {
-            results.push(`'${accumulator.join(' ')}'`);
-            accumulator.length = 0;
-          }
+            if (isStringToken(token)) {
+                accumulator.push(token.value);
+            }
+            if (token.type === TokenType.COMMA_TOKEN) {
+                results.push(`'${accumulator.join(' ')}'`);
+                accumulator.length = 0;
+            }
         });
         if (accumulator.length) {
-          results.push(`'${accumulator.join(' ')}'`);
+            results.push(`'${accumulator.join(' ')}'`);
         }
         console.log(results);
         return results;

--- a/src/css/property-descriptors/font-family.ts
+++ b/src/css/property-descriptors/font-family.ts
@@ -32,6 +32,6 @@ export const fontFamily: IPropertyListDescriptor<FontFamily> = {
         if (accumulator.length) {
             results.push(accumulator.join(' '));
         }
-        return results.map(result => result.includes(' ') ? `'${result}'` : result);
+        return results.map(result => result.indexOf(' ') === -1 ? result : `'${result}'`);
     }
 };

--- a/src/css/property-descriptors/font-family.ts
+++ b/src/css/property-descriptors/font-family.ts
@@ -1,5 +1,5 @@
 import {IPropertyListDescriptor, PropertyDescriptorParsingType} from '../IPropertyDescriptor';
-import {CSSValue, isIdentToken, isStringToken} from '../syntax/parser';
+import {CSSValue, isIdentToken, isNumberToken, isStringToken} from '../syntax/parser';
 import {TokenType} from '../syntax/tokenizer';
 
 export type FONT_FAMILY = string;
@@ -17,6 +17,9 @@ export const fontFamily: IPropertyListDescriptor<FontFamily> = {
         tokens.forEach(token => {
             if (isIdentToken(token) || isStringToken(token)) {
                 accumulator.push(token.value);
+            }
+            if (isNumberToken(token)) {
+                accumulator.push(token.number.toString());
             }
             if (token.type === TokenType.COMMA_TOKEN) {
                 results.push(`'${accumulator.join(' ')}'`);


### PR DESCRIPTION
**Summary**
As noted in #1881, rendering of some named fonts using `html2canvas` can be troublesome.

Many of the reported examples relate to free distribution of the [FontAwesome](https://fontawesome.com/) version 5 fonts.  Web applications using this font frequently set the CSS-based `font-family` property to the string `Font Awesome 5 Free`, as included in some of the default stylesheets ([ref](https://github.com/FortAwesome/Font-Awesome/blob/4e6402443679e0a9d12c7401ac8783ef4646657f/css/regular.css#L6)).

The root cause of the issues encountered when using Font Awesome 5 Free and `html2canvas` in combination is that the latter's [`font-family` parser](https://github.com/niklasvh/html2canvas/blob/4dd4a69c7a2e46c54b5d223fbc94fa4066f19a3c/src/css/property-descriptors/font-family.ts#L14-L16) emits one token for each of the whitespace-or-comma-tokenized input values.

In the case of the string `Font Awesome 5 Free`, this results in three tokens: `['Font', 'Awesome', 'Free']` being passed to the rendering engine (the `5` token does not pass the `isStringToken` filter check).  These are not valid font names, and as a result `html2canvas` renders the styled text incorrectly.

This pull request modifies the parser by ensuring that it concatenates previously-encountered font-family tokens when the parser reaches a termination point (either a comma token, or the end-of-stream).

**Test plan (required)**
These changes have been tested locally under both Firefox and Chrome, and the CI test coverage introduced by #2202 should be useful to provide additional confirmation across other browser environments.

Unit tests to illustrate expected parsing of font names containing numbers and multiple fonts within a property value are included.

**Closing issues**
Fixes #1881 