### PR TITLE
fix the  inconsisencies of HTML element with both  box-shadow and border-radius

### DIFF
--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -483,6 +483,7 @@ export class CanvasRenderer {
     mask(paths: Path[]) {
         this.ctx.beginPath();
         this.ctx.save();
+        // reset tranform to identity
         this.ctx.setTransform(1, 0, 0, 1, 0, 0);
         this.ctx.moveTo(0, 0);
         this.ctx.lineTo(this.canvas.width, 0);
@@ -675,8 +676,8 @@ export class CanvasRenderer {
                     const maskOffset = shadow.inset ? 0 : MASK_OFFSET;
                     const shadowPaintingArea = transformPath(
                         borderBoxArea,
-                        -maskOffset + (shadow.inset ? 1 : -1) * shadow.spread.number,
-                        (shadow.inset ? 1 : -1) * shadow.spread.number,
+                        shadow.offsetX.number - maskOffset + (shadow.inset ? 1 : -1) * shadow.spread.number,
+                        shadow.offsetY.number + (shadow.inset ? 1 : -1) * shadow.spread.number,
                         shadow.spread.number * (shadow.inset ? -2 : 2),
                         shadow.spread.number * (shadow.inset ? -2 : 2)
                     );
@@ -691,8 +692,8 @@ export class CanvasRenderer {
                         this.path(shadowPaintingArea);
                     }
 
-                    this.ctx.shadowOffsetX = shadow.offsetX.number + maskOffset;
-                    this.ctx.shadowOffsetY = shadow.offsetY.number;
+                    this.ctx.shadowOffsetX =  maskOffset;
+                    this.ctx.shadowOffsetY = 0;
                     this.ctx.shadowColor = asString(shadow.color);
                     this.ctx.shadowBlur = shadow.blur.number;
                     this.ctx.fillStyle = shadow.inset ? asString(shadow.color) : 'rgba(0,0,0,1)';

--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -5,7 +5,7 @@ import {ElementContainer} from '../../dom/element-container';
 import {BORDER_STYLE} from '../../css/property-descriptors/border-style';
 import {CSSParsedDeclaration} from '../../css/index';
 import {TextContainer} from '../../dom/text-container';
-import {Path, transformPath, reversePath } from '../path';
+import {Path, transformPath, reversePath} from '../path';
 import {BACKGROUND_CLIP} from '../../css/property-descriptors/background-clip';
 import {BoundCurves, calculateBorderBoxPath, calculateContentBoxPath, calculatePaddingBoxPath} from '../bound-curves';
 import {isBezierCurve} from '../bezier-curve';
@@ -692,7 +692,7 @@ export class CanvasRenderer {
                         this.path(shadowPaintingArea);
                     }
 
-                    this.ctx.shadowOffsetX =  maskOffset;
+                    this.ctx.shadowOffsetX = maskOffset;
                     this.ctx.shadowOffsetY = 0;
                     this.ctx.shadowColor = asString(shadow.color);
                     this.ctx.shadowBlur = shadow.blur.number;

--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -5,7 +5,7 @@ import {ElementContainer} from '../../dom/element-container';
 import {BORDER_STYLE} from '../../css/property-descriptors/border-style';
 import {CSSParsedDeclaration} from '../../css/index';
 import {TextContainer} from '../../dom/text-container';
-import {Path, transformPath} from '../path';
+import {Path, transformPath, reversePath } from '../path';
 import {BACKGROUND_CLIP} from '../../css/property-descriptors/background-clip';
 import {BoundCurves, calculateBorderBoxPath, calculateContentBoxPath, calculatePaddingBoxPath} from '../bound-curves';
 import {isBezierCurve} from '../bezier-curve';
@@ -482,12 +482,15 @@ export class CanvasRenderer {
 
     mask(paths: Path[]) {
         this.ctx.beginPath();
+        this.ctx.save();
+        this.ctx.setTransform(1, 0, 0, 1, 0, 0);
         this.ctx.moveTo(0, 0);
         this.ctx.lineTo(this.canvas.width, 0);
         this.ctx.lineTo(this.canvas.width, this.canvas.height);
         this.ctx.lineTo(0, this.canvas.height);
         this.ctx.lineTo(0, 0);
-        this.formatPath(paths.slice(0).reverse());
+        this.ctx.restore();
+        this.formatPath(reversePath(paths));
         this.ctx.closePath();
     }
 
@@ -663,13 +666,12 @@ export class CanvasRenderer {
             await this.renderBackgroundImage(paint.container);
 
             this.ctx.restore();
-
+            const borderBoxArea = calculateBorderBoxPath(paint.curves);
             styles.boxShadow
                 .slice(0)
                 .reverse()
                 .forEach(shadow => {
                     this.ctx.save();
-                    const borderBoxArea = calculateBorderBoxPath(paint.curves);
                     const maskOffset = shadow.inset ? 0 : MASK_OFFSET;
                     const shadowPaintingArea = transformPath(
                         borderBoxArea,

--- a/src/render/path.ts
+++ b/src/render/path.ts
@@ -35,9 +35,12 @@ export const transformPath = (path: Path[], deltaX: number, deltaY: number, delt
     });
 };
 
-export const reversePath = (path: Path[]) : Path[] => {
-    return path.slice(0).reverse().map((point) => {
-        return point.reverse();
-    });
-}
+export const reversePath = (path: Path[]): Path[] => {
+    return path
+        .slice(0)
+        .reverse()
+        .map(point => {
+            return point.reverse();
+        });
+};
 export type Path = Vector | BezierCurve;

--- a/src/render/path.ts
+++ b/src/render/path.ts
@@ -8,6 +8,7 @@ export enum PathType {
 export interface IPath {
     type: PathType;
     add(deltaX: number, deltaY: number): IPath;
+    reverse(): IPath;
 }
 
 export const equalPath = (a: Path[], b: Path[]): boolean => {
@@ -34,4 +35,9 @@ export const transformPath = (path: Path[], deltaX: number, deltaY: number, delt
     });
 };
 
+export const reversePath = (path: Path[]) : Path[] => {
+    return path.slice(0).reverse().map((point) => {
+        return point.reverse();
+    });
+}
 export type Path = Vector | BezierCurve;

--- a/src/render/vector.ts
+++ b/src/render/vector.ts
@@ -14,6 +14,9 @@ export class Vector implements IPath {
     add(deltaX: number, deltaY: number): Vector {
         return new Vector(this.x + deltaX, this.y + deltaY);
     }
+    reverse(): Vector {
+        return this;
+    }
 }
 
 export const isVector = (path: Path): path is Vector => path.type === PathType.VECTOR;

--- a/tests/reftests/background/box-shadow.html
+++ b/tests/reftests/background/box-shadow.html
@@ -9,7 +9,7 @@
             margin: 10px;
             display: inline-block;
             min-height: 50px;
-       //     border-radius: 10px;
+            border-radius: 10px;
         }
 
         body {


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes the unexpect rendering of HTML element with box-shadow and border-radius styles. It also improve the performance of box-shadow with `inset` property. 

here is the contract while the issues has been sovled:
![no border origin](https://tnl.snapfish.com/assetrenderer/v2/thumbnail/SNAPFISH/_uxKUo0_ou2sWiQ_dOkIYefnZWqfchaTRMgQwD_L7Po/a/M_lqL3jOneX3HHyxfQ1y1Q/d/qhac9fJtVzxe-Z2ExgA-lg/time/WYOfvxd8AzrUblj3DaYclw/h/as3e/m/s2/l/cs/t/jp?height=1920)
*origin html without border*
![no border render](https://tnl.snapfish.com/assetrenderer/v2/thumbnail/SNAPFISH/PxFmJ7RFblAmBQ1z9ErFH-fnZWqfchaTRMgQwD_L7Po/a/M_lqL3jOneX3HHyxfQ1y1Q/d/qhac9fJtVzxe-Z2ExgA-lg/time/O5tNj5-Ek5eqU_f0cqKk2g/h/as3e/m/s2/l/cs/t/jp?height=1920)
*render by html2canvas without border*
![border origin](https://tnl.snapfish.com/assetrenderer/v2/thumbnail/SNAPFISH/xcYPsAuGA0zX2pJpMYatVOfnZWqfchaTRMgQwD_L7Po/a/M_lqL3jOneX3HHyxfQ1y1Q/d/qhac9fJtVzxe-Z2ExgA-lg/time/TwIqif6sC_8OCVntiAeF4w/h/as3e/m/s2/l/cs/t/jp?height=1920)
*origin html with border*
![no border render](https://tnl.snapfish.com/assetrenderer/v2/thumbnail/SNAPFISH/tuLRD5_-QjVePvtX8qOAfOfnZWqfchaTRMgQwD_L7Po/a/M_lqL3jOneX3HHyxfQ1y1Q/d/qhac9fJtVzxe-Z2ExgA-lg/time/izvU6DJVsBS0HenbSjN-Hw/h/as3e/m/s2/l/cs/t/jp?height=1920)
*render by html2canvas with border*
**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #1987
maybeFixed #1856 （I can't assess the jsfiddle, so it not clear whether it was fixed.）