### PR TITLE
Add optional withCredential ResourceOption for CORS images

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,7 @@ These are all of the available configuration options.
 | removeContainer | `true` | Whether to cleanup the cloned DOM elements html2canvas creates temporarily
 | scale | `window.devicePixelRatio` | The scale to use for rendering. Defaults to the browsers device pixel ratio.
 | useCORS | `false` | Whether to attempt to load images from a server using CORS
+| withCredentials | `null` | Whether to set image.crossOrigin to `anonymous` (default) or `use-credentials` (when true)
 | width | `Element` width | The width of the `canvas`
 | height | `Element` height | The height of the `canvas`
 | x | `Element` x-offset | Crop canvas x-coordinate

--- a/src/core/cache-storage.ts
+++ b/src/core/cache-storage.ts
@@ -65,6 +65,7 @@ export interface ResourceOptions {
     imageTimeout: number;
     useCORS: boolean;
     allowTaint: boolean;
+    withCredentials?: boolean;
     proxy?: string;
 }
 
@@ -126,7 +127,11 @@ export class Cache {
             img.onerror = reject;
             //ios safari 10.3 taints canvas with data urls unless crossOrigin is set to anonymous
             if (isInlineBase64Image(src) || useCORS) {
-                img.crossOrigin = 'anonymous';
+                if (this._options.withCredentials) {
+                    img.crossOrigin = 'use-credentials';
+                } else {
+                    img.crossOrigin = 'anonymous';
+                }
             }
             img.src = src;
             if (img.complete === true) {


### PR DESCRIPTION
**Summary**

Problem:
- when requesting a cross-origin image that required cookie based authentication, image retrieval fails as cookies are not attached to GET request

Solution:
- add optional 'withCredentials' toggle to ResourceOptions. Sets `image.crossOrigin` to `use-credentials` when true, otherwise leaves as `anonymous`.

**Test plan (required)**

No tests planned. Would require standing up adding a cookie-auth based mock server for images.
