### PR TITLE
feat: add option to reject when image loading error has occurred.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,7 @@ These are all of the available configuration options.
 | logging | `true` | Enable logging for debug purposes
 | onclone | `null` | Callback function which is called when the Document has been cloned for rendering, can be used to modify the contents that will be rendered without affecting the original source document.
 | proxy | `null` | Url to the [proxy](/proxy/) which is to be used for loading cross-origin images. If left empty, cross-origin images won't be loaded.
+| rejectImageError | `false` | Whether to reject when occurred error on image loading or zero width/height image.
 | removeContainer | `true` | Whether to cleanup the cloned DOM elements html2canvas creates temporarily
 | scale | `window.devicePixelRatio` | The scale to use for rendering. Defaults to the browsers device pixel ratio.
 | useCORS | `false` | Whether to attempt to load images from a server using CORS

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export type Options = CloneOptions &
         foreignObjectRendering: boolean;
         logging: boolean;
         removeContainer?: boolean;
+        rejectImageError: boolean;
     };
 
 const parseColor = (value: string): Color => color.parse(Parser.create(value).parseComponentValue());
@@ -61,6 +62,7 @@ const renderElement = async (element: HTMLElement, opts: Partial<Options>): Prom
         cache: opts.cache ? opts.cache : CacheStorage.create(instanceName, resourceOptions),
         logging: true,
         removeContainer: true,
+        rejectImageError: false,
         foreignObjectRendering: false,
         scale: defaultView.devicePixelRatio || 1,
         windowWidth: defaultView.innerWidth,
@@ -128,7 +130,8 @@ const renderElement = async (element: HTMLElement, opts: Partial<Options>): Prom
         width: options.width,
         height: options.height,
         windowWidth: options.windowWidth,
-        windowHeight: options.windowHeight
+        windowHeight: options.windowHeight,
+        rejectImageError: options.rejectImageError
     };
 
     let canvas;


### PR DESCRIPTION
**Summary**

This PR fixes/implements the following **bugs/features**

* [o] Feature 1 add option to reject when image loading error has occurred.

related to #2424

The original bug is: Safari (iOS/Mac) fail to write image to canvas sometimes.
However, I had no idea to fix this bug. And I found that when I re-called html2canvas, then image was displayed correctly.
So I want to know the output was failed or not, as reject of the promise.

**Test plan (required)**

Sorry, I had no good idea for the test.
But this commit is not breaking any test.

**Code formatting**

Please make sure that code adheres to the project code formatting. Running `npm run format` will automatically format your code correctly.
