### PR TITLE
Added supporting of -webkit-text-stroke, -webkit-text-stroke-color, -webkit-text-stroke-width, paint-order

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -50,6 +50,7 @@ Below is a list of all the supported CSS properties and values.
  - overflow
  - overflow-wrap
  - padding
+ - paint-order
  - position
  - right
  - text-align
@@ -58,7 +59,7 @@ Below is a list of all the supported CSS properties and values.
    - text-decoration-line
    - text-decoration-style (**Only supports `solid`**)
  - text-shadow
- - text-transform 
+ - text-transform
  - top
  - transform (**Limited support**)
  - visibility
@@ -68,6 +69,9 @@ Below is a list of all the supported CSS properties and values.
  - word-spacing
  - word-wrap
  - z-index
+ - -webkit-text-stroke
+   - -webkit-text-stroke-color
+   - -webkit-text-stroke-width
     
 ## Unsupported CSS properties
 These CSS properties are **NOT** currently supported

--- a/src/css/index.ts
+++ b/src/css/index.ts
@@ -44,12 +44,15 @@ import {overflow, OVERFLOW} from './property-descriptors/overflow';
 import {overflowWrap} from './property-descriptors/overflow-wrap';
 import {paddingBottom, paddingLeft, paddingRight, paddingTop} from './property-descriptors/padding';
 import {textAlign} from './property-descriptors/text-align';
+import {paintOrder} from './property-descriptors/paint-order';
 import {position, POSITION} from './property-descriptors/position';
 import {textShadow} from './property-descriptors/text-shadow';
 import {textTransform} from './property-descriptors/text-transform';
 import {transform} from './property-descriptors/transform';
 import {transformOrigin} from './property-descriptors/transform-origin';
 import {visibility, VISIBILITY} from './property-descriptors/visibility';
+import {webkitTextStrokeColor} from './property-descriptors/webkit-text-sroke-color';
+import {webkitTextStrokeWidth} from './property-descriptors/webkit-text-sroke-width';
 import {wordBreak} from './property-descriptors/word-break';
 import {zIndex} from './property-descriptors/z-index';
 import {CSSValue, isIdentToken, Parser} from './syntax/parser';
@@ -125,6 +128,7 @@ export class CSSParsedDeclaration {
     paddingRight: LengthPercentage;
     paddingBottom: LengthPercentage;
     paddingLeft: LengthPercentage;
+    paintOrder: ReturnType<typeof paintOrder.parse>;
     position: ReturnType<typeof position.parse>;
     textAlign: ReturnType<typeof textAlign.parse>;
     textDecorationColor: Color;
@@ -134,6 +138,8 @@ export class CSSParsedDeclaration {
     transform: ReturnType<typeof transform.parse>;
     transformOrigin: ReturnType<typeof transformOrigin.parse>;
     visibility: ReturnType<typeof visibility.parse>;
+    webkitTextStrokeColor: Color;
+    webkitTextStrokeWidth: ReturnType<typeof webkitTextStrokeWidth.parse>;
     wordBreak: ReturnType<typeof wordBreak.parse>;
     zIndex: ReturnType<typeof zIndex.parse>;
 
@@ -189,6 +195,7 @@ export class CSSParsedDeclaration {
         this.paddingRight = parse(paddingRight, declaration.paddingRight);
         this.paddingBottom = parse(paddingBottom, declaration.paddingBottom);
         this.paddingLeft = parse(paddingLeft, declaration.paddingLeft);
+        this.paintOrder = parse(paintOrder, declaration.paintOrder);
         this.position = parse(position, declaration.position);
         this.textAlign = parse(textAlign, declaration.textAlign);
         this.textDecorationColor = parse(textDecorationColor, declaration.textDecorationColor || declaration.color);
@@ -198,6 +205,8 @@ export class CSSParsedDeclaration {
         this.transform = parse(transform, declaration.transform);
         this.transformOrigin = parse(transformOrigin, declaration.transformOrigin);
         this.visibility = parse(visibility, declaration.visibility);
+        this.webkitTextStrokeColor = parse(webkitTextStrokeColor, declaration.webkitTextStrokeColor);
+        this.webkitTextStrokeWidth = parse(webkitTextStrokeWidth, declaration.webkitTextStrokeWidth);
         this.wordBreak = parse(wordBreak, declaration.wordBreak);
         this.zIndex = parse(zIndex, declaration.zIndex);
     }

--- a/src/css/property-descriptors/__tests__/paintOrder.ts
+++ b/src/css/property-descriptors/__tests__/paintOrder.ts
@@ -1,0 +1,75 @@
+import {deepStrictEqual} from 'assert';
+import {Parser} from '../../syntax/parser';
+import {paintOrder, PAINT_ORDER_LAYER} from '../paint-order';
+
+const paintOrderParse = (value: string) => paintOrder.parse(Parser.parseValues(value));
+
+describe('property-descriptors', () => {
+    describe('paint-order', () => {
+        it('none', () => deepStrictEqual(paintOrderParse('none'), [
+            PAINT_ORDER_LAYER.FILL,
+            PAINT_ORDER_LAYER.STROKE,
+            PAINT_ORDER_LAYER.MARKERS
+        ]));
+
+        it('EMPTY', () => deepStrictEqual(paintOrderParse(''), [
+            PAINT_ORDER_LAYER.FILL,
+            PAINT_ORDER_LAYER.STROKE,
+            PAINT_ORDER_LAYER.MARKERS
+        ]));
+
+        it('other values', () => deepStrictEqual(paintOrderParse('other values'), [
+            PAINT_ORDER_LAYER.FILL,
+            PAINT_ORDER_LAYER.STROKE,
+            PAINT_ORDER_LAYER.MARKERS
+        ]));
+
+        it('normal', () => deepStrictEqual(paintOrderParse('normal'), [
+            PAINT_ORDER_LAYER.FILL,
+            PAINT_ORDER_LAYER.STROKE,
+            PAINT_ORDER_LAYER.MARKERS
+        ]));
+
+        it('stroke', () => deepStrictEqual(paintOrderParse('stroke'), [
+            PAINT_ORDER_LAYER.STROKE,
+            PAINT_ORDER_LAYER.FILL,
+            PAINT_ORDER_LAYER.MARKERS
+        ]));
+        
+        it('fill', () => deepStrictEqual(paintOrderParse('fill'), [
+            PAINT_ORDER_LAYER.FILL,
+            PAINT_ORDER_LAYER.STROKE,
+            PAINT_ORDER_LAYER.MARKERS
+        ]));
+        
+        it('markers', () => deepStrictEqual(paintOrderParse('markers'), [
+            PAINT_ORDER_LAYER.MARKERS,
+            PAINT_ORDER_LAYER.FILL,
+            PAINT_ORDER_LAYER.STROKE
+        ]));
+        
+        it('stroke fill', () => deepStrictEqual(paintOrderParse('stroke fill'), [
+            PAINT_ORDER_LAYER.STROKE,
+            PAINT_ORDER_LAYER.FILL,
+            PAINT_ORDER_LAYER.MARKERS
+        ]));
+        
+        it('markers stroke', () => deepStrictEqual(paintOrderParse('markers stroke'), [
+            PAINT_ORDER_LAYER.MARKERS,
+            PAINT_ORDER_LAYER.STROKE,
+            PAINT_ORDER_LAYER.FILL
+        ]));
+        
+        it('markers stroke fill', () => deepStrictEqual(paintOrderParse('markers stroke fill'), [
+            PAINT_ORDER_LAYER.MARKERS,
+            PAINT_ORDER_LAYER.STROKE,
+            PAINT_ORDER_LAYER.FILL
+        ]));
+        
+        it('stroke fill markers', () => deepStrictEqual(paintOrderParse('stroke fill markers'), [
+            PAINT_ORDER_LAYER.STROKE,
+            PAINT_ORDER_LAYER.FILL,
+            PAINT_ORDER_LAYER.MARKERS
+        ]));
+    });
+});

--- a/src/css/property-descriptors/paint-order.ts
+++ b/src/css/property-descriptors/paint-order.ts
@@ -1,0 +1,46 @@
+import {IPropertyListDescriptor, PropertyDescriptorParsingType} from '../IPropertyDescriptor';
+import {CSSValue, isIdentToken} from '../syntax/parser';
+export enum PAINT_ORDER_LAYER {
+    FILL,
+    STROKE,
+    MARKERS
+}
+
+export type PaintOrder = PAINT_ORDER_LAYER[];
+
+export const paintOrder: IPropertyListDescriptor<PaintOrder> = {
+    name: 'paint-order',
+    initialValue: 'normal',
+    prefix: false,
+    type: PropertyDescriptorParsingType.LIST,
+    parse: (tokens: CSSValue[]): PaintOrder => {
+        const DEFAULT_VALUE = [PAINT_ORDER_LAYER.FILL, PAINT_ORDER_LAYER.STROKE, PAINT_ORDER_LAYER.MARKERS];
+        let layers: PaintOrder = [];
+
+        tokens.filter(isIdentToken).forEach(token => {
+            switch (token.value) {
+                case 'stroke':
+                    layers.push(PAINT_ORDER_LAYER.STROKE);
+                    break;
+                case 'fill':
+                    layers.push(PAINT_ORDER_LAYER.FILL);
+                    break;
+                case 'markers':
+                    layers.push(PAINT_ORDER_LAYER.MARKERS);
+                    break;
+            }
+        });
+        DEFAULT_VALUE.forEach(value => {
+            if (layers.indexOf(value) === -1) {
+                layers.push(value);
+            }
+        });
+
+        if (!layers.length || !!(window as any).chrome) {
+            layers = DEFAULT_VALUE;
+        }
+        return layers;
+    }
+};
+
+

--- a/src/css/property-descriptors/webkit-text-sroke-color.ts
+++ b/src/css/property-descriptors/webkit-text-sroke-color.ts
@@ -1,0 +1,8 @@
+import {IPropertyTypeValueDescriptor, PropertyDescriptorParsingType} from '../IPropertyDescriptor';
+export const webkitTextStrokeColor: IPropertyTypeValueDescriptor = {
+    name: `-webkit-text-stroke-color`,
+    initialValue: 'currentcolor',
+    prefix: false,
+    type: PropertyDescriptorParsingType.TYPE_VALUE,
+    format: 'color'
+};

--- a/src/css/property-descriptors/webkit-text-sroke-width.ts
+++ b/src/css/property-descriptors/webkit-text-sroke-width.ts
@@ -1,0 +1,15 @@
+import {CSSValue, isDimensionToken} from '../syntax/parser';
+import {IPropertyValueDescriptor, PropertyDescriptorParsingType} from '../IPropertyDescriptor';
+export const webkitTextStrokeWidth: IPropertyValueDescriptor<number> = {
+    name: `-webkit-text-stroke-width`,
+    initialValue: '0',
+    type: PropertyDescriptorParsingType.VALUE,
+    prefix: false,
+    parse: (token: CSSValue): number => {
+        if (isDimensionToken(token)) {
+            return token.number;
+        }
+        return 0;
+    }
+};
+

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -2,6 +2,7 @@ interface CSSStyleDeclaration {
     textDecorationColor: string | null;
     textDecorationLine: string | null;
     overflowWrap: string | null;
+    paintOrder: string | null;
 }
 
 interface DocumentType extends Node, ChildNode {

--- a/tests/reftests/text/webkit-text-stroke.html
+++ b/tests/reftests/text/webkit-text-stroke.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Text webkit-text-stroke tests</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <script type="text/javascript" src="../../test.js"></script>
+    <style>
+        .stroke1 {
+            -webkit-text-stroke-width: .09em;
+            -webkit-text-stroke-color: red;
+            font-size: 1em;
+        }
+        .stroke2 {
+            -webkit-text-stroke-width: .12em;
+            -webkit-text-stroke-color: rgba(0, 255, 0, .5);
+            letter-spacing: .2em;
+            font-size: 2em;
+        }
+        .stroke3 {
+            -webkit-text-stroke-width: .12em;
+            -webkit-text-stroke-color:  rgb(0, 0, 255);
+            color: #444444;
+            font-size: 3em;
+        }
+        .stroke4 {
+            -webkit-text-stroke-width: .09em;
+            -webkit-text-stroke-color: #FF00FF;
+            color: #FFFFFF;
+            font-size: 4em;
+        }
+        .stroke5 {
+            -webkit-text-stroke: .1em #999919;
+            font-size: 5em;
+            color: #FFFFFF00;
+        }
+
+        .ordered {
+            paint-order: stroke fill;
+        }
+
+        body {
+            font-family: Arial;
+        }
+    </style>
+</head>
+<body>
+<div class="stroke1">
+    Some text <span> with bigger text </span> that should have a stroke
+    <strong>Bolder stroke</strong> that makes things pretty
+</div>
+<div class="stroke2">
+    Some text <span> with bigger text </span> that should have a stroke
+    <strong>Bolder stroke</strong> that makes things pretty
+</div>
+<div class="stroke3">
+    Some text <span> with bigger text </span> that should have a stroke
+    <strong>Bolder stroke</strong> that makes things pretty
+</div>
+<div class="stroke4">
+    Some text <span> with bigger text </span> that should have a stroke
+    <strong>Bolder stroke</strong> that makes things pretty
+</div>
+<div class="stroke5">
+    Some text <span> with bigger text </span> that should have a stroke
+    <strong>Bolder stroke</strong> that makes things pretty
+</div>
+<div class="stroke1 ordered">
+    Some text <span> with bigger text </span> that should have a stroke
+    <strong>Bolder stroke</strong> that makes things pretty
+</div>
+<div class="stroke2 ordered">
+    Some text <span> with bigger text </span> that should have a stroke
+    <strong>Bolder stroke</strong> that makes things pretty
+</div>
+<div class="stroke3 ordered">
+    Some text <span> with bigger text </span> that should have a stroke
+    <strong>Bolder stroke</strong> that makes things pretty
+</div>
+<div class="stroke4 ordered">
+    Some text <span> with bigger text </span> that should have a stroke
+    <strong>Bolder stroke</strong> that makes things pretty
+</div>
+<div class="stroke5 ordered">
+    Some text <span> with bigger text </span> that should have a stroke
+    <strong>Bolder stroke</strong> that makes things pretty
+</div>
+</body>
+</html>


### PR DESCRIPTION
**Added supporting of -webkit-text-stroke, -webkit-text-stroke-color, -webkit-text-stroke-width, paint-order + fixes for Chrome (paint-order)**

These fixes are based on this [PR](https://github.com/niklasvh/html2canvas/pull/1540) and **1.0.0-rc.7**.

This ads support for `-webkit-text-stroke`, `-webkit-text-stroke-width`, `-webkit-text-stroke-color`, and `paint-order`.

Note that even through these are webkit prefixes, Firefox still uses them.

`paint-order` is required in order to get strokes to render as an outline of the text and not in the middle.

`paint-order` does not currently work fully in chrome, as chrome reads the value of the property, but does not apply it in the dom. Firefox and Safari work just fine.

Added checking of chrome browser to make it work predictably in chrome.

Added unittest for `paint-order` descriptor. See src/css/property-descriptors/__tests__/paintOrder.ts.

See tests/reftests/text/webkit-text-stroke.html for an example.

Here is a link to use it like `npm install html2canvas-stroke2`:
[www.npmjs.com/package/html2canvas-stroke2](https://www.npmjs.com/package/html2canvas-stroke2)