### PR TITLE
feat: add flag to disable copyCssStyles for SVG elements

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ These are all of the available configuration options.
 | onclone | `null` | Callback function which is called when the Document has been cloned for rendering, can be used to modify the contents that will be rendered without affecting the original source document.
 | proxy | `null` | Url to the [proxy](/proxy/) which is to be used for loading cross-origin images. If left empty, cross-origin images won't be loaded.
 | removeContainer | `true` | Whether to cleanup the cloned DOM elements html2canvas creates temporarily
+| copyStylesInSVG | `true` | Whether to copy all computed styles inside every SVG node
 | scale | `window.devicePixelRatio` | The scale to use for rendering. Defaults to the browsers device pixel ratio.
 | useCORS | `false` | Whether to attempt to load images from a server using CORS
 | width | `Element` width | The width of the `canvas`

--- a/src/dom/document-cloner.ts
+++ b/src/dom/document-cloner.ts
@@ -25,6 +25,7 @@ export interface CloneOptions {
     id: string;
     ignoreElements?: (element: Element) => boolean;
     onclone?: (document: Document) => void;
+    copyStylesInSVG?: boolean;
 }
 
 export type CloneConfigurations = CloneOptions & {
@@ -306,7 +307,12 @@ export class DocumentCloner {
 
             this.counters.pop(counters);
 
-            if (style && (this.options.copyStyles || isSVGElementNode(node)) && !isIFrameElement(node)) {
+            if (
+                style &&
+                this.options.copyStylesInSVG &&
+                (this.options.copyStyles || isSVGElementNode(node)) &&
+                !isIFrameElement(node)
+            ) {
                 copyCSSStyles(style, clone);
             }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,8 @@ const renderElement = async (element: HTMLElement, opts: Partial<Options>): Prom
         onclone: options.onclone,
         ignoreElements: options.ignoreElements,
         inlineImages: options.foreignObjectRendering,
-        copyStyles: options.foreignObjectRendering
+        copyStyles: options.foreignObjectRendering,
+        copyStylesInSVG: options.copyStylesInSVG == null ? true : options.copyStylesInSVG
     });
     const clonedElement = documentCloner.clonedReferenceElement;
     if (!clonedElement) {


### PR DESCRIPTION
**Summary**

This PR implements the following **features**

* [x] fixes https://github.com/niklasvh/html2canvas/issues/2495
The ability to turn "copyCssStyles" off for SVG nodes

**Closing issues**
closes https://github.com/niklasvh/html2canvas/issues/2495
