### PR TITLE
fix: inline escaped SVG data-uri make canvas tainted in Safari between iOS 10-11.2

### DIFF
--- a/src/core/cache-storage.ts
+++ b/src/core/cache-storage.ts
@@ -94,7 +94,7 @@ export class Cache {
             img.onload = () => resolve(img);
             img.onerror = reject;
             //ios safari 10.3 taints canvas with data urls unless crossOrigin is set to anonymous
-            if (isInlineBase64Image(src) || useCORS) {
+            if (isInlineImage(src) || useCORS) {
                 img.crossOrigin = 'anonymous';
             }
             img.src = src;
@@ -166,12 +166,10 @@ export class Cache {
 }
 
 const INLINE_SVG = /^data:image\/svg\+xml/i;
-const INLINE_BASE64 = /^data:image\/.*;base64,/i;
 const INLINE_IMG = /^data:image\/.*/i;
 
 const isRenderable = (src: string): boolean => FEATURES.SUPPORT_SVG_DRAWING || !isSVG(src);
 const isInlineImage = (src: string): boolean => INLINE_IMG.test(src);
-const isInlineBase64Image = (src: string): boolean => INLINE_BASE64.test(src);
 const isBlobImage = (src: string): boolean => src.substr(0, 4) === 'blob';
 
 const isSVG = (src: string): boolean => src.substr(-3).toLowerCase() === 'svg' || INLINE_SVG.test(src);

--- a/tests/reftests/background/svg.html
+++ b/tests/reftests/background/svg.html
@@ -1,0 +1,22 @@
+<html>
+<head>
+    <title>Escaped SVG background tests</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <script type="text/javascript" src="../../test.js"></script>
+    <style>
+        .svg {
+            position: absolute;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='605' height='2'%3E%3Cpath stroke='%23F00' stroke-dasharray='11,11' d='M.25.25l604 .25'/%3E%3C/svg%3E");
+            background-size: contain;
+            background-repeat: no-repeat;
+            width: 500px;
+            height: 20px;
+        }
+    </style>
+</head>
+<body>
+    <div class='svg'>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
# Summary

This PR fixes/implements the following **bugs/features**

* [x] Inline escaped SVG data-uri make canvas tainted in Safari between iOS 10.3 - 11.2

## What is escaped SVG data-uri?

Before, developers can put inline SVG data-uri into CSS like this.
```CSS
.icon-arrow-down {
    width: 20px; height: 20px;
    background: url('data:image/svg+xml;utf8,<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200"><path fill="#00A5E0" d="M145.659,68.949c-5.101-5.208-13.372-5.208-18.473,0L99.479,97.233 L71.772,68.949c-5.1-5.208-13.371-5.208-18.473,0c-5.099,5.208-5.099,13.648,0,18.857l46.18,47.14l46.181-47.14 C150.759,82.598,150.759,74.157,145.659,68.949z"/></svg>') no-repeat center;
    background-size: 100%;
}
```
However, modern browsers do not support some characters like "，%，#，{，}，<，> in the data-uri anymore. Using base64 encoded SVG data-uri can bypass this problem, but it is not a good practice since the length will increase by 1/3.

The best practice (also with best compatibility) is to 'encodeURIComponent' the SVG data-uri. After that, the code like this:
```CSS
.icon-arrow-down {
    width: 20px; height: 20px;
    background: url("data:image/svg+xml,%3Csvg version='1.1' xmlns='http://www.w3.org/2000/svg' width='200' height='200' viewBox='0 0 200 200'%3E%3Cpath fill='%2300A5E0' d='M145.659,68.949c-5.101-5.208-13.372-5.208-18.473,0L99.479,97.233 L71.772,68.949c-5.1-5.208-13.371-5.208-18.473,0c-5.099,5.208-5.099,13.648,0,18.857l46.18,47.14l46.181-47.14 C150.759,82.598,150.759,74.157,145.659,68.949z'/%3E%3C/svg%3E") no-repeat center;
    background-size: 100%;
}
```
[demo](https://codepen.io/emon100/pen/VwWvmVj)

## What is the problem with Safari?

Safari between iOS 10.3-11.2 will need the 'crossorigin' attribute on the img tag to load not only base64 encoded data-uri but all kinds of data-uri.
#1797 tried to fix this problem, but I found when the data-uri isn't base 64 the problem still exists.

In my humble opinion, I suggest load every data-uri with the 'crossorigin' attribute. 

# Test plan (required)

Test case was added in the `tests/reftests/background/svg.html`.

# Closing issues

Fixes this comment: https://github.com/niklasvh/html2canvas/issues/1575#issuecomment-418763593

