### PR TITLE
fix(font): ios13+ font loading error

### DIFF
--- a/src/dom/document-cloner.ts
+++ b/src/dom/document-cloner.ts
@@ -109,8 +109,18 @@ export class DocumentCloner {
                 return Promise.reject(`Error finding the ${this.referenceElement.nodeName} in the cloned document`);
             }
 
-            if (documentClone.fonts && documentClone.fonts.status === 'loading' && documentClone.fonts.ready) {
-                await documentClone.fonts.ready;
+            if (documentClone.fonts && documentClone.fonts.status === 'loading') {
+                return Promise.race([
+                    documentClone.fonts.ready,
+                    new Promise<void>((resolve) => {
+                        const fontLoadTimer = setInterval(() => {
+                            if (documentClone.fonts.status === 'loaded') {
+                                clearInterval(fontLoadTimer);
+                                resolve();
+                            }
+                        }, 1000);
+                    })
+                ]);
             }
 
             if (/(AppleWebKit)/g.test(navigator.userAgent)) {

--- a/src/dom/document-cloner.ts
+++ b/src/dom/document-cloner.ts
@@ -109,7 +109,7 @@ export class DocumentCloner {
                 return Promise.reject(`Error finding the ${this.referenceElement.nodeName} in the cloned document`);
             }
 
-            if (documentClone.fonts && documentClone.fonts.status === "loading" && documentClone.fonts.ready) {
+            if (documentClone.fonts && documentClone.fonts.status === 'loading' && documentClone.fonts.ready) {
                 await documentClone.fonts.ready;
             }
 

--- a/src/dom/document-cloner.ts
+++ b/src/dom/document-cloner.ts
@@ -109,7 +109,7 @@ export class DocumentCloner {
                 return Promise.reject(`Error finding the ${this.referenceElement.nodeName} in the cloned document`);
             }
 
-            if (documentClone.fonts && documentClone.fonts.ready) {
+            if (documentClone.fonts && documentClone.fonts.status === "loading" && documentClone.fonts.ready) {
                 await documentClone.fonts.ready;
             }
 


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

In ios 13+, documents fonts loaded,but documents.fonts.ready(promise) do not resolve but in pending,So that the whole process is pending. i add a status check to resolve this.When fonts is  already loaded,it don't need to do the ready.


**Closing issues**

Fixes  https://github.com/niklasvh/html2canvas/issues/2191
