### PR TITLE
fix issues with conflicting styles causing baseline for fonts to be wrong.

### DIFF
--- a/src/render/font-metrics.ts
+++ b/src/render/font-metrics.ts
@@ -27,21 +27,28 @@ export class FontMetrics {
         container.style.fontSize = fontSize;
         container.style.margin = '0';
         container.style.padding = '0';
+        container.style.position = 'absolute';
+        container.style.top = '-1000px';
 
         body.appendChild(container);
 
         img.src = SMALL_IMAGE;
         img.width = 1;
         img.height = 1;
+        img.style.width = '1px';
+        img.style.height = '1px';
 
         img.style.margin = '0';
         img.style.padding = '0';
         img.style.verticalAlign = 'baseline';
+        img.style.display = 'inline-block';
 
         span.style.fontFamily = fontFamily;
         span.style.fontSize = fontSize;
         span.style.margin = '0';
         span.style.padding = '0';
+        span.style.lineHeight = 'normal';
+        span.style.height = 'auto';
 
         span.appendChild(this._document.createTextNode(SAMPLE_TEXT));
         container.appendChild(span);

--- a/tests/reftests/text/text.html
+++ b/tests/reftests/text/text.html
@@ -7,6 +7,7 @@
     <style>
         body {
             font-family: Arial;
+            display: flex;
         }
 
         .small {


### PR DESCRIPTION
**Summary**

When css targeting body, spans and images exist it can cause the baseline to be calculated incorrectly.

for example display: flex on body will cause it to miscalculate the baseline.

This PR fixes/implements the following **bugs/features**

* [x] Text alignment issues with miscalculated baseline


Explain the **motivation** for making this change. What existing problem does the pull request solve?

When css properties on body change the offset for the container for calculating the baseline, the baseline is wrong and results in text that is not aligned correctly.

**Test plan (required)**

Set body css to flex, can also target span and img but its not necessary. I've added this in the reftests in text and its kind of reflected in my change.

This PR might fix the text alignment issue #1888 but I haven't checked that specific issue.

closing remarks are the styles could use !important but since they are inline I doubt that matters.

Before:
![Screenshot 2021-09-20 200145](https://user-images.githubusercontent.com/1455933/133972103-aec08583-6cc5-455f-9256-1f12bfce6472.png)

After:
![Screenshot 2021-09-20 200200](https://user-images.githubusercontent.com/1455933/133972143-dc8acf72-1b5d-4d98-89a3-3ff2c13633bd.png)




