### PR TITLE
Enhance: Add encoding step when setting href

### DIFF
--- a/src/core/cache-storage.ts
+++ b/src/core/cache-storage.ts
@@ -11,8 +11,8 @@ export class CacheStorage {
             return 'about:blank';
         }
 
-        link.href = url;
-        link.href = link.href; // IE9, LOL! - http://jsfiddle.net/niklasvh/2e48b/
+        link.href = encodeURI(url);
+        link.href = encodeURI(link.href); // IE9, LOL! - http://jsfiddle.net/niklasvh/2e48b/
         return link.protocol + link.hostname + link.port;
     }
 


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**
* [x] Add encoding steps for `getOrigin(url)` method

Nowadays customers pay more attention on security awareness, and they may use some 3rd-party tools like Veracode to scan the products they used.
And these tools may report issues ([CWE 80 Basic XSS](https://cwe.mitre.org/data/definitions/80.html)) in the changed codes:
`link.href = url;`
Because they consider it may have DOM based XSS vulnerability.

We all know that this is a False Alarm, there is no security concern about XSS in this codes, because we only use current web-site's URL and the image links in the current page for this method. If these links has XSS concerns, then the original web-site also has.
And though we create a new `a` tag, but it is not added to the web-site and will never be triggered. So even there is XSS concerns for the passed-in URL, it will never be executed.

However, I suppose it will be better that we update our codes to avoid reporting this False Alarm by those 3rd-party tools. Then peoples use `html2canvas` doesn't need to explain to their customers why there is a flaw here. So I simply add `encodeURL` step here.

The code change should be safe, since in the method `isSameOrigin`, both two values are encoded by the same step, so it will not break `isSameOrigin` method at all.

Please help review. Thanks.

**Test plan (required)**

I have passed all the existing tests, and no new test cases are needed.

**Code formatting**

Please make sure that code adheres to the project code formatting. Running `npm run format` will automatically format your code correctly.

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #2390 
