### PR TITLE
Improve text performance by combining words in the same line

### DIFF
--- a/src/css/layout/text.ts
+++ b/src/css/layout/text.ts
@@ -22,7 +22,7 @@ export const parseTextBounds = (
     styles: CSSParsedDeclaration,
     node: Text
 ): TextBounds[] => {
-    const textList = breakText(value, styles);
+    const textList = breakText(value, styles, node);
     const textBounds: TextBounds[] = [];
     let offset = 0;
     textList.forEach((text) => {
@@ -86,8 +86,34 @@ const getRangeBounds = (context: Context, node: Text, offset: number, length: nu
     return Bounds.fromClientRect(context, createRange(node, offset, length).getBoundingClientRect());
 };
 
-const breakText = (value: string, styles: CSSParsedDeclaration): string[] => {
-    return styles.letterSpacing !== 0 ? splitGraphemes(value) : breakWords(value, styles);
+const breakText = (value: string, styles: CSSParsedDeclaration, node: Text): string[] => {
+    return styles.letterSpacing !== 0 ? splitGraphemes(value) : breakLines(value, styles, node);
+};
+
+const breakLines = (value: string, styles: CSSParsedDeclaration, node: Text): string[] => {
+    const words = breakWords(value, styles);
+    const lines: string[] = [];
+
+    let offset = 0;
+    let acc = '';
+
+    for (const word of words) {
+        const rects = createRange(node, offset, acc.length + word.length).getClientRects();
+
+        if (rects.length <= 1) {
+            acc += word;
+        } else {
+            offset += acc.length;
+            lines.push(acc);
+            acc = word;
+        }
+    }
+
+    if (acc.length > 0) {
+        lines.push(acc);
+    }
+
+    return lines;
 };
 
 // https://drafts.csswg.org/css-text/#word-separator


### PR DESCRIPTION
**Summary**

Normally, html2canvas splits the text into words before rendering for word wrapping to work correctly. However this causes too many calls to `ctx.fillText` as each word is rendered separately.

This PR combines multiple words in each line so that only one `fillText` call is done for each line.

Note that this does not change anything if `letter-spacing` is not `0`. Because each letter (grapheme) should be rendered separately in that case.

> Explain the **motivation** for making this change. What existing problem does the pull request solve?

The performance cost itself is normally not a big deal. But I made this fix specifically for this issue in `jsPDF`: https://github.com/parallax/jsPDF/issues/3137

`jsPDF` uses a different canvas implementation and each call to `fillText` increases the performance cost. This PR can reduce the number of render calls about 10 times.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

> Demonstrate how the issue/feature can be replicated. For most cases, simply adding an appropriate html/css template into the [reftests](https://github.com/niklasvh/html2canvas/tree/master/tests/reftests) should be sufficient. Please see other tests there for reference.

This should not change any functionality or how the text is rendered. It just increases the text rendering performance. The effect of rendering performance to an image may be unnoticable. But it will be noticable for users of jsPDF.

**Code formatting**

> Please make sure that code adheres to the project code formatting. Running `npm run format` will automatically format your code correctly.

Done.
