### PR TITLE
prevent image resolution loss

### DIFF
--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -603,7 +603,9 @@ export class CanvasRenderer extends Renderer {
                     ]);
                     // prevent image resolution loss: render and copy img at current scale, instead of downscaling then rescaling
                     // recalculate for null transformation
-                    path = path.map(function(v){v.x = (v.x-this.options.x)*this.options.scale; v.y = (v.y-this.options.y)*this.options.scale; return v});
+                    path = (path as Vector[]).map(v => {
+                        return new Vector((v.x-this.options.x)*this.options.scale, (v.y-this.options.y)*this.options.scale);
+                    });
                     x = (x - this.options.x) * this.options.scale;
                     y = (y - this.options.y) * this.options.scale;
                     width *= this.options.scale;


### PR DESCRIPTION
Render and copy images at the current scale, instead of downscaling first thus losing resolution, then rescaling them.

**Summary**

Render images without losing resolution.

This PR fixes/implements the following **bugs**

* [ ] Bug 1: images lose resolution when the scale is greater than 1

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Example image generated **after** the fix:
![image](https://user-images.githubusercontent.com/2893181/136047891-baee9c5a-ea5f-48b6-8f8d-f558c7d114a5.png)

Original rendering with version 1.3.2:
![image](https://user-images.githubusercontent.com/2893181/136048019-277fbac8-92da-45fc-9788-5593e5fdca30.png)
