### PR TITLE
外部LPでサムネイル画像にLP中の画像が表示されない場合がある

### DIFF
--- a/src/core/cache-storage.ts
+++ b/src/core/cache-storage.ts
@@ -97,7 +97,9 @@ export class Cache {
             if (isInlineBase64Image(src) || useCORS) {
                 img.crossOrigin = 'anonymous';
             }
-            img.src = src;
+            // キャッシュにより画像が読み込めないエラーの回避のため後ろにランダムな文字列を挿入する
+            // 参考URL: https://www.fixes.pub/program/136376.html
+            img.src = src + '?_' + this.makeRndStr();
             if (img.complete === true) {
                 // Inline XML images may fail to parse, throwing an Error later on
                 setTimeout(() => resolve(img), 500);
@@ -109,6 +111,16 @@ export class Cache {
                 );
             }
         });
+    }
+
+    private makeRndStr() {
+        let strLen: number = 5;
+        let rndStr: string = '';
+        let possible: string = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        for (let i = 0; i < strLen; i++) {
+            rndStr = possible.charAt(Math.floor(Math.random() * possible.length));
+        }
+        return rndStr;
     }
 
     private has(key: string): boolean {


### PR DESCRIPTION
## 概要
外部LPでサムネイル画像にLP中の画像が表示されない場合があったため修正した
原因はhtml2Canvasがキャッシュから画像を読み込んでいたことで、以下のURLの方法に従い修正しました
https://www.fixes.pub/program/136376.html