### PR TITLE
Fix "offsets" text when font is big enought and screen is width of mobile screen bug 

### DIFF
--- a/src/render/font-metrics.ts
+++ b/src/render/font-metrics.ts
@@ -27,6 +27,7 @@ export class FontMetrics {
         container.style.fontSize = fontSize;
         container.style.margin = '0';
         container.style.padding = '0';
+        container.style.whiteSpace = 'nowrap';
 
         body.appendChild(container);
 


### PR DESCRIPTION
A similar PR may already be submitted!
Please search among the [Pull request](https://github.com/niklasvh/html2canvas/pulls) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

Before opening a pull request, please make sure all the tests pass locally by running `npm test`.

**Summary**

Fix "offsets" text when font is big enought and screen is width of mobile screen bug 

This PR fixes/implements the following **bugs**

html2canvas "offsets" text when font is big enough and screen is small;

Tested with a small mobile screen width and font size of 100px;
The problem does not occurs when screen is larger and it does not depends on the size of the container.

sample following

https://codepen.io/daniel-dia/pen/KKmjwEw


The problem is: The creation and measurement of font metrics is based on `SAMPLE_TEXT` a text with a space

`const SAMPLE_TEXT = 'Hidden Text';`

In a condition that the font size an family for the text above overflows the current window width, then the container breaks a line, "Hidden [line break] Text". This doubles the size of the text offset. That is the problem

Adding the following property to the font metrics container `whiteSpace = 'nowrap';` solves the problem.

best regards.

**Closing issues**

Fixes #2666
Fixes #2693
