### PR TITLE
Fix missing CustomElement children

### DIFF
--- a/src/dom/node-parser.ts
+++ b/src/dom/node-parser.ts
@@ -39,11 +39,7 @@ const parseNodeTree = (context: Context, node: Node, parent: ElementContainer, r
                     parseNodeTree(context, childNode.shadowRoot, container, root);
                 }
 
-                if (
-                    !isTextareaElement(childNode) &&
-                    !isSVGElement(childNode) &&
-                    !isSelectElement(childNode)
-                ) {
+                if (!isTextareaElement(childNode) && !isSVGElement(childNode) && !isSelectElement(childNode)) {
                     parseNodeTree(context, childNode, container, root);
                 }
             }

--- a/src/dom/node-parser.ts
+++ b/src/dom/node-parser.ts
@@ -21,32 +21,30 @@ const parseNodeTree = (context: Context, node: Node, parent: ElementContainer, r
         if (isTextNode(childNode) && childNode.data.trim().length > 0) {
             parent.textNodes.push(new TextContainer(context, childNode, parent.styles));
         } else if (isElementNode(childNode)) {
-            if (isSlotElement(childNode) && childNode.assignedNodes) {
-                childNode.assignedNodes().forEach((childNode) => parseNodeTree(context, childNode, parent, root));
-            } else {
-                const container = createContainer(context, childNode);
-                if (container.styles.isVisible()) {
-                    if (createsRealStackingContext(childNode, container, root)) {
-                        container.flags |= FLAGS.CREATES_REAL_STACKING_CONTEXT;
-                    } else if (createsStackingContext(container.styles)) {
-                        container.flags |= FLAGS.CREATES_STACKING_CONTEXT;
-                    }
+            const container = createContainer(context, childNode);
+            if (container.styles.isVisible()) {
+                if (createsRealStackingContext(childNode, container, root)) {
+                    container.flags |= FLAGS.CREATES_REAL_STACKING_CONTEXT;
+                } else if (createsStackingContext(container.styles)) {
+                    container.flags |= FLAGS.CREATES_STACKING_CONTEXT;
+                }
 
-                    if (LIST_OWNERS.indexOf(childNode.tagName) !== -1) {
-                        container.flags |= FLAGS.IS_LIST_OWNER;
-                    }
+                if (LIST_OWNERS.indexOf(childNode.tagName) !== -1) {
+                    container.flags |= FLAGS.IS_LIST_OWNER;
+                }
 
-                    parent.elements.push(container);
-                    childNode.slot;
-                    if (childNode.shadowRoot) {
-                        parseNodeTree(context, childNode.shadowRoot, container, root);
-                    } else if (
-                        !isTextareaElement(childNode) &&
-                        !isSVGElement(childNode) &&
-                        !isSelectElement(childNode)
-                    ) {
-                        parseNodeTree(context, childNode, container, root);
-                    }
+                parent.elements.push(container);
+
+                if (childNode.shadowRoot) {
+                    parseNodeTree(context, childNode.shadowRoot, container, root);
+                }
+
+                if (
+                    !isTextareaElement(childNode) &&
+                    !isSVGElement(childNode) &&
+                    !isSelectElement(childNode)
+                ) {
+                    parseNodeTree(context, childNode, container, root);
                 }
             }
         }
@@ -130,4 +128,3 @@ export const isStyleElement = (node: Element): node is HTMLStyleElement => node.
 export const isScriptElement = (node: Element): node is HTMLScriptElement => node.tagName === 'SCRIPT';
 export const isTextareaElement = (node: Element): node is HTMLTextAreaElement => node.tagName === 'TEXTAREA';
 export const isSelectElement = (node: Element): node is HTMLSelectElement => node.tagName === 'SELECT';
-export const isSlotElement = (node: Element): node is HTMLSlotElement => node.tagName === 'SLOT';


### PR DESCRIPTION
This PR fixes the following **bugs**:

* [Bug with missing CustomElement children](https://github.com/niklasvh/html2canvas/pull/2581#issuecomment-953280213)

The motivation of these changes is that for now CustomElements is parsing incorrectly.

On [line 18](https://github.com/niklasvh/html2canvas/blob/eeda86bd5e81fb4e97675fe9bee3d4d15899997f/src/dom/node-parser.ts#L18) we calling ``firstChild`` property:
```javascript
for (let childNode = node.firstChild, nextNode; childNode; childNode = nextNode) {
```

However on [line 25](https://github.com/niklasvh/html2canvas/blob/eeda86bd5e81fb4e97675fe9bee3d4d15899997f/src/dom/node-parser.ts#L25) we passing ``childNode`` itself, instead of ``childNode.parentNode`` (the parent of the node assigned to slot):
```javascript
childNode.assignedNodes().forEach((childNode) => parseNodeTree(context, childNode, parent, root));
```
This cause missing ``firstChild`` property on [line 18](https://github.com/niklasvh/html2canvas/blob/eeda86bd5e81fb4e97675fe9bee3d4d15899997f/src/dom/node-parser.ts#L18).

Furthermore, even if we pass ``childNode.parentNode``, we are losing ``slot`` default content nodes as there is no place in code where we are parsing slot tree:
```javascript
<slot>
    <div>Some default content</div>
</slot>
```

We must parse [children](https://github.com/niklasvh/html2canvas/blob/eeda86bd5e81fb4e97675fe9bee3d4d15899997f/src/dom/node-parser.ts#L43) along with [shadowRoot](https://github.com/niklasvh/html2canvas/blob/eeda86bd5e81fb4e97675fe9bee3d4d15899997f/src/dom/node-parser.ts#L41) at the same point:
```javascript
if (childNode.shadowRoot) {
    parseNodeTree(context, childNode.shadowRoot, container, root);
}

if (!isTextareaElement(childNode) && !isSVGElement(childNode) && !isSelectElement(childNode)) {
    parseNodeTree(context, childNode, container, root);
}
```

The reason for this is that children are ***already in LightDOM*** and it is not required to get assigned nodes through the ``slot`` element itself.

Also we must parse ``slot`` as default element, so we must remove this condition:
```javascript
if (isSlotElement(childNode) && childNode.assignedNodes) {
```

