### PR TITLE
Add font style to font metrics

### DIFF
--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -175,14 +175,14 @@ export class CanvasRenderer extends Renderer {
     }
 
     async renderTextNode(text: TextContainer, styles: CSSParsedDeclaration): Promise<void> {
-        const [font, fontFamily, fontSize] = this.createFontStyle(styles);
+        const [font] = this.createFontStyle(styles);
 
         this.ctx.font = font;
 
         this.ctx.direction = styles.direction === DIRECTION.RTL ? 'rtl' : 'ltr';
         this.ctx.textAlign = 'left';
         this.ctx.textBaseline = 'alphabetic';
-        const {baseline, middle} = this.fontMetrics.getMetrics(fontFamily, fontSize);
+        const {baseline, middle} = this.fontMetrics.getMetrics(font);
         const paintOrder = styles.paintOrder;
 
         text.textBounds.forEach((text) => {
@@ -389,10 +389,10 @@ export class CanvasRenderer extends Renderer {
         }
 
         if (isTextInputElement(container) && container.value.length) {
-            const [fontFamily, fontSize] = this.createFontStyle(styles);
-            const {baseline} = this.fontMetrics.getMetrics(fontFamily, fontSize);
+            const [font] = this.createFontStyle(styles);
+            const {baseline} = this.fontMetrics.getMetrics(font);
 
-            this.ctx.font = fontFamily;
+            this.ctx.font = font;
             this.ctx.fillStyle = asString(styles.color);
 
             this.ctx.textBaseline = 'alphabetic';

--- a/src/render/font-metrics.ts
+++ b/src/render/font-metrics.ts
@@ -15,7 +15,7 @@ export class FontMetrics {
         this._document = document;
     }
 
-    private parseMetrics(fontFamily: string, fontSize: string): FontMetric {
+    private parseMetrics(font: string): FontMetric {
         const container = this._document.createElement('div');
         const img = this._document.createElement('img');
         const span = this._document.createElement('span');
@@ -23,8 +23,7 @@ export class FontMetrics {
         const body = this._document.body as HTMLBodyElement;
 
         container.style.visibility = 'hidden';
-        container.style.fontFamily = fontFamily;
-        container.style.fontSize = fontSize;
+        container.style.font = font;
         container.style.margin = '0';
         container.style.padding = '0';
 
@@ -38,8 +37,7 @@ export class FontMetrics {
         img.style.padding = '0';
         img.style.verticalAlign = 'baseline';
 
-        span.style.fontFamily = fontFamily;
-        span.style.fontSize = fontSize;
+        span.style.font = font;
         span.style.margin = '0';
         span.style.padding = '0';
 
@@ -60,10 +58,10 @@ export class FontMetrics {
 
         return {baseline, middle};
     }
-    getMetrics(fontFamily: string, fontSize: string): FontMetric {
-        const key = `${fontFamily} ${fontSize}`;
+    getMetrics(font: string): FontMetric {
+        const key = font;
         if (typeof this._data[key] === 'undefined') {
-            this._data[key] = this.parseMetrics(fontFamily, fontSize);
+            this._data[key] = this.parseMetrics(font);
         }
 
         return this._data[key];

--- a/tests/reftests/text/text.html
+++ b/tests/reftests/text/text.html
@@ -151,11 +151,11 @@
 <div>Emojis 🤷🏾‍♂️👨‍👩‍👧‍👦 :)</div>
 <div style="letter-spacing: 2px">Emojis with letter-spacing 🤷🏾‍♂️👨‍👩‍👧‍👦 :)</div>
 
-<h3>&lt;h3&gt; alignment of italic font style with normal</h3>
+<h2>&lt;h2&gt; alignment of italic font style with normal</h2>
 <p  
   style="
      font-family: Sans;
-     font-size: 50px;
+     font-size: 30px;
      color: black;
   "
 >

--- a/tests/reftests/text/text.html
+++ b/tests/reftests/text/text.html
@@ -150,7 +150,8 @@
 </div>
 <div>Emojis 🤷🏾‍♂️👨‍👩‍👧‍👦 :)</div>
 <div style="letter-spacing: 2px">Emojis with letter-spacing 🤷🏾‍♂️👨‍👩‍👧‍👦 :)</div>
-<h3>&lt;h3&gt; alignment of italic font style with normal</h1>
+
+<h3>&lt;h3&gt; alignment of italic font style with normal</h3>
 <p  
   style="
      font-family: Sans;

--- a/tests/reftests/text/text.html
+++ b/tests/reftests/text/text.html
@@ -150,5 +150,16 @@
 </div>
 <div>Emojis 🤷🏾‍♂️👨‍👩‍👧‍👦 :)</div>
 <div style="letter-spacing: 2px">Emojis with letter-spacing 🤷🏾‍♂️👨‍👩‍👧‍👦 :)</div>
+<h3>&lt;h3&gt; alignment of italic font style with normal</h1>
+<p  
+  style="
+     font-family: Sans;
+     font-size: 50px;
+     color: black;
+  "
+>
+  <span style="font-style: normal;">font-style: normal; </span>
+  <span style="font-style: italic;">font-style: italic; </span>
+</p>
 </body>
 </html>


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes the following **bug**

* [V] a text with an italic font style is not aligned to the baseline 

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Fantastic library! 

One small issue: text with italic font can be rendered higher than it should.

It happens because a span with an italic version of a font can have bigger height than normal, so the baseline should be lower for the italic version. 

Currently FontMetrics is calculated without font style, so for an italic version of a font a normal font baseline is used. 

This simple PR adds font style to font metrics calculation.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan**

[This fiddle](https://jsfiddle.net/nf695g1c/1/) is with current release version of the library.
![without-PR](https://user-images.githubusercontent.com/72052173/145224847-48b94097-42da-4207-9b00-2db94000ddf8.png)

[This fiddle](https://jsfiddle.net/bf0q968w/1/) is with this PR included.
![with-PR](https://user-images.githubusercontent.com/72052173/145224882-1d1a7aaa-c5d3-429c-8030-de70166c2cc6.png)

Reftest is at the bottom of [this file](https://github.com/alexandr-panchenko/html2canvas/blob/add-font-style-to-font-metrics/tests/reftests/text/text.html)
