### PR TITLE
fix: getBoundingClientRect x and y properties in older browsers

### DIFF
--- a/src/css/layout/bounds.ts
+++ b/src/css/layout/bounds.ts
@@ -20,8 +20,8 @@ export class Bounds {
         const domRect = Array.from(domRectList).find((rect) => rect.width !== 0);
         return domRect
             ? new Bounds(
-                  domRect.x + context.windowBounds.left,
-                  domRect.y + context.windowBounds.top,
+                  domRect.left + context.windowBounds.left,
+                  domRect.top + context.windowBounds.top,
                   domRect.width,
                   domRect.height
               )


### PR DESCRIPTION
fix: Properties x and y of BoundingRect is undefined in old browser like Chrome/52.0.2743.100

Fixes: #2770
Fixes: #2733
