### PR TITLE
Fix chrome issue with the crossOrigin images

### DIFF
--- a/src/core/cache-storage.ts
+++ b/src/core/cache-storage.ts
@@ -96,6 +96,10 @@ export class Cache {
             //ios safari 10.3 taints canvas with data urls unless crossOrigin is set to anonymous
             if (isInlineBase64Image(src) || useCORS) {
                 img.crossOrigin = 'anonymous';
+                // in chrome if the image loaded before without crossorigin it will be cached and used later even if the next usage has crossorigin
+                // so it will fail with CORS error, so add a random query parameter just to prevent the chrome from using the cached image
+                // see more info about the chrome issue in this link: https://stackoverflow.com/a/49503414
+                src = src + (src.indexOf('?') === -1 ? '?' : '&') + 'cacheBusting=1';
             }
             img.src = src;
             if (img.complete === true) {


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->
In Chrome browser if the image loaded before without crossorigin it will be cached and used later even if the next usage has crossorigin so it will fail with CORS error.
so add a random query parameter just to prevent the Chrome from using the cached image.

see more info about the Chrome issue in this link: https://stackoverflow.com/a/49503414

This PR fixes/implements the following **bugs/features**

* [x] Bug 1
* [ ] Bug 2
* [ ] Feature 1
* [ ] Feature 2
* [ ] Breaking changes

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Demonstrate how the issue/feature can be replicated. For most cases, simply adding an appropriate html/css template into the [reftests](https://github.com/niklasvh/html2canvas/tree/master/tests/reftests) should be sufficient. Please see other tests there for reference.

**Code formatting**

Please make sure that code adheres to the project code formatting. Running `npm run format` will automatically format your code correctly.

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
