### PR TITLE
fix: the rendering order of transform and clip effects

### DIFF
--- a/src/render/stacking-context.ts
+++ b/src/render/stacking-context.ts
@@ -70,7 +70,6 @@ export class ElementPaint {
         while (parent) {
             const croplessEffects = parent.effects.filter((effect) => !isClipEffect(effect));
             if (inFlow || parent.container.styles.position !== POSITION.STATIC || !parent.parent) {
-                effects.unshift(...croplessEffects);
                 inFlow = [POSITION.ABSOLUTE, POSITION.FIXED].indexOf(parent.container.styles.position) === -1;
                 if (parent.container.styles.overflowX !== OVERFLOW.VISIBLE) {
                     const borderBox = calculateBorderBoxPath(parent.curves);
@@ -81,6 +80,7 @@ export class ElementPaint {
                         );
                     }
                 }
+                effects.unshift(...croplessEffects);
             } else {
                 effects.unshift(...croplessEffects);
             }


### PR DESCRIPTION
Rendering clip effects before rendering transform effects would lead to a wrong clip area.

**Test plan (required)**

reftest-diff

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #2825 
