### PR TITLE
Fix cloned children of custom element shadowRoot cloned outside shadowRoot

### DIFF
--- a/tests/reftests/webcomponents/autonomous-custom-element.js
+++ b/tests/reftests/webcomponents/autonomous-custom-element.js
@@ -18,6 +18,13 @@ class AutonomousCustomElement extends HTMLElement {
         const style = document.createElement('style');
 
         style.textContent = `
+
+      /* Non-namespaced style that will leak into the page DOM if the style
+         is cloned outside of a shadow root*/
+      body {
+        background: red;
+      }
+
       .wrapper {
         position: relative;
       }


### PR DESCRIPTION
**Summary**

Updates the cloning code for custom HTML elements so that if a child node was originally inside a shadowRoot it is cloned into a shadowRoot inside the container iframe. This resolves an issue most commonly reported here related to the Grammarly Chrome extension (see #2804), but can also prevent custom elements from leaking loosely-scoped styles into the main page DOM in other situations.

In the specific case of the Grammarly extension, they create a custom HTML element appended to the page with a shadowRoot, with a `<style>` element containing a rule with the selector `div {}`. Normally on a page this functions fine because the stylesheet only applies inside the shadowRoot, but when it gets appended directly to the DOM of the container iframe it applies to every `<div>` in the frame.

![image](https://user-images.githubusercontent.com/2308923/153659235-767c7391-c5d8-41ba-9534-6b9e51288855.png)

**Updates**

In `createCustomElementClone`:
- Change the name of the custom HTML element to "html2canvas-custom-element" (with hyphens) so the element can have a shadowRoot attached
- Attaches a shadow to the cloned element on compatible browsers (not IE9-11)

In `appendChildNode`:
- Adds a parameter `isInShadow` that tells the function when a cloned child is being cloned inside a shadowRoot to append the child to the clone's shadowRoot instead of the normal cloned element

In `cloneChildNodes`:
- Detects whether the node being cloned is inside a shadowRoot in the original document and, if so, passes to `appendChildNode` with the new `isInShadow` parameter set to false

**Test plan (required)**

Primarily relies on the existing `webcomponents` reftest. If the primary logic functions correctly, the elements should all appear the same as they did before, since they're unaffected by being inside/outside of a shadowRoot.

I added an extra CSS attribute to `autonomous-custom-element.js` with the selector `body`, which will turn the background of the entire page red if the stylesheet gets appended to the main DOM instead of being contained within a shadowRoot. When it's properly contained within a shadowRoot, it has no effect on the appearance of the screenshot.

For manual testing, you can enable the Grammarly extension from the Chrome Web Store (you don't need to complete registration, simply install and enable the extension) and use the screenshot button on https://html2canvas.hertzen.com/. On the current 1.4.1 version, the screenshot canvas will appear blank because all the `div` elements will be clipped by Grammarly's unscoped stylesheet.

**Closing issues**

Closes #2804
Closes #2819
