### PR TITLE
Set display inline for font metrics test img

### DIFF
--- a/src/render/font-metrics.ts
+++ b/src/render/font-metrics.ts
@@ -38,6 +38,7 @@ export class FontMetrics {
         img.style.margin = '0';
         img.style.padding = '0';
         img.style.verticalAlign = 'baseline';
+        img.style.display = 'inline';
 
         span.style.fontFamily = fontFamily;
         span.style.fontSize = fontSize;

--- a/tests/reftests/text/text.html
+++ b/tests/reftests/text/text.html
@@ -14,6 +14,10 @@
             line-height: 1vw;
         }
 
+        img {
+            display: block;
+        }
+
         .medium {
             font-size: 18px;
             line-height: 2vw;


### PR DESCRIPTION
**Summary**

CSS in the parent page (e.g. `img { display: block; }`) that changes the `display` property of images on the page results in extra padding before text when the `parseMetrics` function goes to calculate text height. Setting the style of the test image to `inline` resolves the issue. See #2829.

This PR fixes/implements the following **bugs/features**

* Force parseMetrics test img to display inline

**Test plan (required)**

Updated `reftests/text/text.html` with an img CSS declaration that demonstrates the bug. Since the specific image is created only for the purposes of calculating font metrics, it should not affect any other elements.

**Closing issues**

Closes #2829 
