### PR TITLE
Support right/center/bottom background-positions

### DIFF
--- a/src/css/property-descriptors/background-position.ts
+++ b/src/css/property-descriptors/background-position.ts
@@ -1,6 +1,6 @@
 import {PropertyDescriptorParsingType, IPropertyListDescriptor} from '../IPropertyDescriptor';
-import {CSSValue, parseFunctionArgs} from '../syntax/parser';
-import {isLengthPercentage, LengthPercentageTuple, parseLengthPercentageTuple} from '../types/length-percentage';
+import {parseFunctionArgs} from '../syntax/parser';
+import {LengthPercentageTuple, parseLengthPercentageTuple} from '../types/length-percentage';
 import {Context} from '../../core/context';
 export type BackgroundPosition = BackgroundImagePosition[];
 
@@ -11,7 +11,7 @@ export const backgroundPosition: IPropertyListDescriptor<BackgroundPosition> = {
     initialValue: '0% 0%',
     type: PropertyDescriptorParsingType.LIST,
     prefix: false,
-    parse: (_context: Context, tokens: CSSValue[]): BackgroundPosition => {
-        return parseFunctionArgs(tokens);
+    parse: (_context: Context, tokens: LengthPercentageTuple): BackgroundPosition => {
+        return parseFunctionArgs(tokens).map(parseLengthPercentageTuple);
     }
 };

--- a/src/css/property-descriptors/background-position.ts
+++ b/src/css/property-descriptors/background-position.ts
@@ -12,8 +12,6 @@ export const backgroundPosition: IPropertyListDescriptor<BackgroundPosition> = {
     type: PropertyDescriptorParsingType.LIST,
     prefix: false,
     parse: (_context: Context, tokens: CSSValue[]): BackgroundPosition => {
-        return parseFunctionArgs(tokens)
-            .map((values: CSSValue[]) => values.filter(isLengthPercentage))
-            .map(parseLengthPercentageTuple);
+        return parseFunctionArgs(tokens);
     }
 };

--- a/src/css/syntax/tokenizer.ts
+++ b/src/css/syntax/tokenizer.ts
@@ -97,6 +97,17 @@ export interface DimensionToken extends IToken {
     number: number;
 }
 
+export interface IdentToken extends IToken {
+    type: TokenType.IDENT_TOKEN;
+    value: string;
+}
+
+export interface FunctionToken extends IToken {
+    type: TokenType.FUNCTION;
+    name: string;
+    values: Array<CSSToken>;
+}
+
 export interface UnicodeRangeToken extends IToken {
     type: TokenType.UNICODE_RANGE_TOKEN;
     start: number;

--- a/src/css/types/length-percentage.ts
+++ b/src/css/types/length-percentage.ts
@@ -128,17 +128,17 @@ export const resolveThreeValueSyntax = (
         absoluteX = getAbsoluteValue(tuple[0], width);
 
         if (tuple[1].type == TokenType.DIMENSION_TOKEN && tuple[0].number == 100) {
-          absoluteX = getAbsoluteValue(tuple[0], width) - getAbsoluteValue(tuple[1], width);
+            absoluteX = getAbsoluteValue(tuple[0], width) - getAbsoluteValue(tuple[1], width);
         }
 
         if (tuple[2].type == TokenType.PERCENTAGE_TOKEN) {
-          absoluteY = getAbsoluteValue(tuple[2], height);
+            absoluteY = getAbsoluteValue(tuple[2], height);
         }
     }
 
     if (tuple[1].type == TokenType.PERCENTAGE_TOKEN) {
         if (tuple[1].number == 100) {
-          absoluteY = getAbsoluteValue(tuple[1], height) - getAbsoluteValue(tuple[2], height);
+            absoluteY = getAbsoluteValue(tuple[1], height) - getAbsoluteValue(tuple[2], height);
         }
     }
 

--- a/src/css/types/length-percentage.ts
+++ b/src/css/types/length-percentage.ts
@@ -130,6 +130,17 @@ export const getAbsoluteValue = (token: LengthPercentage, parent: number): numbe
         }
     }
 
+    // Firefox translates positions like "right 20px" as calc(100% + 20px)
+    if (token.type === TokenType.FUNCTION) {
+        if (token.name === 'calc' && token.values.length == 5) {
+            let firstValue = getAbsoluteValue(token.values[0], parent);
+            let secondValue = getAbsoluteValue(token.values[4], parent);
+
+            if (token.values[2].value == '-') return firstValue - secondValue;
+            if (token.values[2].value == '+') return firstValue + secondValue;
+        }
+    }
+
     if (isDimensionToken(token)) {
         switch (token.unit) {
             case 'rem':

--- a/src/css/types/length-percentage.ts
+++ b/src/css/types/length-percentage.ts
@@ -1,13 +1,30 @@
-import {DimensionToken, FLAG_INTEGER, NumberValueToken, TokenType} from '../syntax/tokenizer';
+import {
+    DimensionToken,
+    FLAG_INTEGER,
+    FunctionToken,
+    IdentToken,
+    NumberValueToken,
+    TokenType
+} from '../syntax/tokenizer';
 import {CSSValue, isDimensionToken} from '../syntax/parser';
 import {isLength} from './length';
 export type LengthPercentage = DimensionToken | NumberValueToken;
-export type LengthPercentageTuple = [LengthPercentage] | [LengthPercentage, LengthPercentage];
+export type LengthValue = LengthPercentage | IdentToken | FunctionToken;
+export type LengthAnchor = IdentToken | LengthValue;
+export type LengthPercentageTuple =
+    | [LengthValue]
+    | [LengthValue, LengthValue]
+    | [LengthAnchor, LengthAnchor, LengthAnchor]
+    | [LengthAnchor, LengthValue, LengthAnchor, LengthValue];
 
 export const isLengthPercentage = (token: CSSValue): token is LengthPercentage =>
     token.type === TokenType.PERCENTAGE_TOKEN || isLength(token);
-export const parseLengthPercentageTuple = (tokens: LengthPercentage[]): LengthPercentageTuple =>
-    tokens.length > 1 ? [tokens[0], tokens[1]] : [tokens[0]];
+export const parseLengthPercentageTuple = (tokens: LengthPercentage[]): LengthPercentageTuple => {
+    if (tokens.length == 4)
+        return [<LengthAnchor>tokens[0], <LengthValue>tokens[1], <LengthAnchor>tokens[2], <LengthValue>tokens[3]];
+    if (tokens.length == 3) return [<LengthAnchor>tokens[0], <LengthAnchor>tokens[1], <LengthAnchor>tokens[2]];
+    return tokens.length > 1 ? [tokens[0], tokens[1]] : [tokens[0]];
+};
 export const ZERO_LENGTH: NumberValueToken = {
     type: TokenType.NUMBER_TOKEN,
     number: 0,
@@ -31,89 +48,123 @@ export const getAbsoluteValueForTuple = (
     width: number,
     height: number
 ): [number, number] => {
+    if (tuple.length == 3) {
+        return resolveThreeValueSyntax(tuple, width, height);
+    }
+
+    if (tuple.length == 4) {
+        return resolveFourValueSyntax(tuple, width, height);
+    }
+
     let [x, y] = tuple;
     let absoluteX = getAbsoluteValue(x, width);
     let absoluteY = getAbsoluteValue(typeof y !== 'undefined' ? y : x, height);
 
+    return [absoluteX, absoluteY];
+};
+
+export const resolveThreeValueSyntax = (
+    tuple: [LengthAnchor, LengthAnchor, LengthAnchor],
+    width: number,
+    height: number
+): [number, number] => {
+    let absoluteX = 0;
+    let absoluteY = 0;
+
     // https://developer.mozilla.org/en-US/docs/Web/CSS/background-position#values
     // With 3-value syntax, there are two keywords, and an offset that modifies the
     // preceding keyword
-    if (tuple.length == 3) {
-        // If the first keyword is "left" or "right", we start with the X position
-        if (tuple[0].value == 'left' || tuple[0].value == 'right') {
-            // If the second tuple is an offset, apply it to the X position
-            if (tuple[1].type == TokenType.PERCENTAGE_TOKEN || tuple[1].type == TokenType.DIMENSION_TOKEN) {
-                if (tuple[0].value == 'left') absoluteX = getAbsoluteValue(tuple[1], width);
-                if (tuple[0].value == 'right') absoluteX = width - getAbsoluteValue(tuple[1], width);
-            }
 
-            // If the second tuple is a keyword, X position is left or right
-            if (tuple[1].type == TokenType.IDENT_TOKEN) {
-                if (tuple[0].value == 'left') absoluteX = getAbsoluteValue(tuple[0], width);
-                if (tuple[0].value == 'right') absoluteX = width - getAbsoluteValue(tuple[0], width);
-            }
-
-            // If the first keyword is left/right and the last is 50%, we know that's
-            // vertical centering
-            if (tuple[2].type == TokenType.PERCENTAGE_TOKEN) {
-                absoluteY = getAbsoluteValue(tuple[2], height);
-            }
+    // If the first keyword is "left" or "right", we start with the X position
+    if (tuple[0].type == TokenType.IDENT_TOKEN && (tuple[0].value == 'left' || tuple[0].value == 'right')) {
+        // If the second tuple is an offset, apply it to the X position
+        if (tuple[1].type == TokenType.PERCENTAGE_TOKEN || tuple[1].type == TokenType.DIMENSION_TOKEN) {
+            if (tuple[0].value == 'left') absoluteX = getAbsoluteValue(tuple[1], width);
+            if (tuple[0].value == 'right') absoluteX = width - getAbsoluteValue(tuple[1], width);
         }
 
-        // If the third tuple is an offset (meaning the first two are keywords) it modifies
-        // the second tuple keyword
-        if (tuple[2].type == TokenType.PERCENTAGE_TOKEN || tuple[2].type == TokenType.DIMENSION_TOKEN) {
-            if (tuple[1].value == 'top') absoluteY = getAbsoluteValue(tuple[2], height);
-            if (tuple[1].value == 'bottom') absoluteY = height - getAbsoluteValue(tuple[2], height);
-            if (tuple[1].value == 'left') absoluteX = getAbsoluteValue(tuple[2], width);
-            if (tuple[1].value == 'right') absoluteX = width - getAbsoluteValue(tuple[2], width);
+        // If the second tuple is a keyword, X position is left or right
+        if (tuple[1].type == TokenType.IDENT_TOKEN) {
+            if (tuple[0].value == 'left') absoluteX = getAbsoluteValue(tuple[0], width);
+            if (tuple[0].value == 'right') absoluteX = width - getAbsoluteValue(tuple[0], width);
         }
 
-        // If the first keyword is "center" we check to see if the other keyword is left/right
-        // to see if this applies to Y, otherwise assume X
-        if (tuple[0].value == 'center') {
-            if (
-                tuple[1].value !== 'left' &&
-                tuple[1].value !== 'right' &&
-                tuple[2].value !== 'left' &&
-                tuple[2].value !== 'right'
-            ) {
-                absoluteX = getAbsoluteValue(tuple[0], width);
-            }
-
-            if (tuple[1].value == 'left' || tuple[1].value == 'right') {
-                absoluteY = getAbsoluteValue(tuple[0], height);
-            }
-        }
-
-        if (tuple[1].value == 'center' || tuple[2].value == 'center') {
-            if (tuple[0].value == 'right' || tuple[0].value == 'right') {
-                absoluteY = getAbsoluteValue(tuple[2], height);
-            }
+        // If the first keyword is left/right and the last is 50%, we know that's
+        // vertical centering
+        if (tuple[2].type == TokenType.PERCENTAGE_TOKEN) {
+            absoluteY = getAbsoluteValue(tuple[2], height);
         }
     }
 
-    // With 4-value syntax, the 1st and 3rd values are keywords, and the 2nd and 4th
-    // are offsets for each of them respectively
-    if (tuple.length == 4) {
-        if (tuple[0].type == TokenType.IDENT_TOKEN) {
-            if (tuple[0].value == 'left') absoluteX = getAbsoluteValue(tuple[1], width);
-            if (tuple[0].value == 'right') absoluteX = width - getAbsoluteValue(tuple[1], width);
-            if (tuple[0].value == 'top') absoluteY = getAbsoluteValue(tuple[1], height);
-            if (tuple[0].value == 'bottom') absoluteY = height - getAbsoluteValue(tuple[1], height);
+    // If the third tuple is an offset (meaning the first two are keywords) it modifies
+    // the second tuple keyword
+    if (
+        tuple[1].type == TokenType.IDENT_TOKEN &&
+        (tuple[2].type == TokenType.PERCENTAGE_TOKEN || tuple[2].type == TokenType.DIMENSION_TOKEN)
+    ) {
+        if (tuple[1].value == 'top') absoluteY = getAbsoluteValue(tuple[2], height);
+        if (tuple[1].value == 'bottom') absoluteY = height - getAbsoluteValue(tuple[2], height);
+        if (tuple[1].value == 'left') absoluteX = getAbsoluteValue(tuple[2], width);
+        if (tuple[1].value == 'right') absoluteX = width - getAbsoluteValue(tuple[2], width);
+    }
+
+    // If the first keyword is "center" we check to see if the other keyword is left/right
+    // to see if this applies to Y, otherwise assume X
+    if (tuple[0].type == TokenType.IDENT_TOKEN && tuple[0].value == 'center') {
+        if (
+            (tuple[1].type == TokenType.IDENT_TOKEN && tuple[1].value !== 'left' && tuple[1].value !== 'right') ||
+            (tuple[2].type == TokenType.IDENT_TOKEN && tuple[2].value !== 'left' && tuple[2].value !== 'right')
+        ) {
+            absoluteX = getAbsoluteValue(tuple[0], width);
         }
 
-        if (tuple[2].type == TokenType.IDENT_TOKEN) {
-            if (tuple[2].value == 'top') absoluteY = getAbsoluteValue(tuple[3], height);
-            if (tuple[2].value == 'bottom') absoluteY = height - getAbsoluteValue(tuple[3], height);
-            if (tuple[2].value == 'left') absoluteX = getAbsoluteValue(tuple[3], width);
-            if (tuple[2].value == 'right') absoluteX = width - getAbsoluteValue(tuple[3], width);
+        if (tuple[1].type == TokenType.IDENT_TOKEN && (tuple[1].value == 'left' || tuple[1].value == 'right')) {
+            absoluteY = getAbsoluteValue(tuple[0], height);
+        }
+    }
+
+    if (
+        (tuple[1].type == TokenType.IDENT_TOKEN && tuple[1].value == 'center') ||
+        (tuple[2].type == TokenType.IDENT_TOKEN && tuple[2].value == 'center')
+    ) {
+        if (tuple[0].type == TokenType.IDENT_TOKEN && (tuple[0].value == 'right' || tuple[0].value == 'right')) {
+            absoluteY = getAbsoluteValue(tuple[2], height);
         }
     }
 
     return [absoluteX, absoluteY];
 };
-export const getAbsoluteValue = (token: LengthPercentage, parent: number): number => {
+
+export const resolveFourValueSyntax = (
+    tuple: [LengthAnchor, LengthValue, LengthAnchor, LengthValue],
+    width: number,
+    height: number
+): [number, number] => {
+    let absoluteX = 0;
+    let absoluteY = 0;
+
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/background-position#values
+    // With 4-value syntax, the 1st and 3rd values are keywords, and the 2nd and 4th
+    // are offsets for each of them respectively
+
+    if (tuple[0].type == TokenType.IDENT_TOKEN) {
+        if (tuple[0].value == 'left') absoluteX = getAbsoluteValue(tuple[1], width);
+        if (tuple[0].value == 'right') absoluteX = width - getAbsoluteValue(tuple[1], width);
+        if (tuple[0].value == 'top') absoluteY = getAbsoluteValue(tuple[1], height);
+        if (tuple[0].value == 'bottom') absoluteY = height - getAbsoluteValue(tuple[1], height);
+    }
+
+    if (tuple[2].type == TokenType.IDENT_TOKEN) {
+        if (tuple[2].value == 'top') absoluteY = getAbsoluteValue(tuple[3], height);
+        if (tuple[2].value == 'bottom') absoluteY = height - getAbsoluteValue(tuple[3], height);
+        if (tuple[2].value == 'left') absoluteX = getAbsoluteValue(tuple[3], width);
+        if (tuple[2].value == 'right') absoluteX = width - getAbsoluteValue(tuple[3], width);
+    }
+
+    return [absoluteX, absoluteY];
+};
+
+export const getAbsoluteValue = (token: LengthValue, parent: number): number => {
     if (token.type === TokenType.PERCENTAGE_TOKEN) {
         return (token.number / 100) * parent;
     }
@@ -130,15 +181,18 @@ export const getAbsoluteValue = (token: LengthPercentage, parent: number): numbe
         }
     }
 
-    // Firefox translates positions like "right 20px" as calc(100% + 20px)
+    // Handle (simple) length calculations, e.g. Firefox translates background positions like "right 20px" as calc(100% + 20px)
     if (token.type === TokenType.FUNCTION) {
         if (token.name === 'calc' && token.values.length == 5) {
-            let firstValue = getAbsoluteValue(token.values[0], parent);
-            let secondValue = getAbsoluteValue(token.values[4], parent);
+            let firstValue = getAbsoluteValue(<LengthPercentage>token.values[0], parent);
+            let secondValue = getAbsoluteValue(<LengthPercentage>token.values[4], parent);
 
-            if (token.values[2].value == '-') return firstValue - secondValue;
-            if (token.values[2].value == '+') return firstValue + secondValue;
+            if (token.values[2].type == TokenType.DELIM_TOKEN && token.values[2].value == '-')
+                return firstValue - secondValue;
+            if (token.values[2].type == TokenType.DELIM_TOKEN && token.values[2].value == '+')
+                return firstValue + secondValue;
         }
+        return 0;
     }
 
     if (isDimensionToken(token)) {

--- a/src/css/types/length-percentage.ts
+++ b/src/css/types/length-percentage.ts
@@ -123,6 +123,25 @@ export const resolveThreeValueSyntax = (
         }
     }
 
+    // Older Internet Explorer will translate e.g. "center bottom -40px" into "50%", "100%", "-40px"
+    if (tuple[0].type == TokenType.PERCENTAGE_TOKEN) {
+        absoluteX = getAbsoluteValue(tuple[0], width);
+
+        if (tuple[1].type == TokenType.DIMENSION_TOKEN && tuple[0].number == 100) {
+          absoluteX = getAbsoluteValue(tuple[0], width) - getAbsoluteValue(tuple[1], width);
+        }
+
+        if (tuple[2].type == TokenType.PERCENTAGE_TOKEN) {
+          absoluteY = getAbsoluteValue(tuple[2], height);
+        }
+    }
+
+    if (tuple[1].type == TokenType.PERCENTAGE_TOKEN) {
+        if (tuple[1].number == 100) {
+          absoluteY = getAbsoluteValue(tuple[1], height) - getAbsoluteValue(tuple[2], height);
+        }
+    }
+
     if (
         (tuple[1].type == TokenType.IDENT_TOKEN && tuple[1].value == 'center') ||
         (tuple[2].type == TokenType.IDENT_TOKEN && tuple[2].value == 'center')
@@ -159,6 +178,20 @@ export const resolveFourValueSyntax = (
         if (tuple[2].value == 'bottom') absoluteY = height - getAbsoluteValue(tuple[3], height);
         if (tuple[2].value == 'left') absoluteX = getAbsoluteValue(tuple[3], width);
         if (tuple[2].value == 'right') absoluteX = width - getAbsoluteValue(tuple[3], width);
+    }
+
+    if (tuple[0].type == TokenType.PERCENTAGE_TOKEN || isDimensionToken(tuple[0])) {
+        absoluteX = getAbsoluteValue(tuple[0], width) + getAbsoluteValue(tuple[1], width);
+        if (tuple[0].number == 100) {
+            absoluteX = getAbsoluteValue(tuple[0], width) - getAbsoluteValue(tuple[1], width);
+        }
+    }
+
+    if (tuple[2].type == TokenType.PERCENTAGE_TOKEN || isDimensionToken(tuple[2])) {
+        absoluteY = getAbsoluteValue(tuple[2], height) + getAbsoluteValue(tuple[3], height);
+        if (tuple[2].number == 100) {
+            absoluteY = getAbsoluteValue(tuple[2], height) - getAbsoluteValue(tuple[3], height);
+        }
     }
 
     return [absoluteX, absoluteY];

--- a/src/css/types/length-percentage.ts
+++ b/src/css/types/length-percentage.ts
@@ -31,12 +31,103 @@ export const getAbsoluteValueForTuple = (
     width: number,
     height: number
 ): [number, number] => {
-    const [x, y] = tuple;
-    return [getAbsoluteValue(x, width), getAbsoluteValue(typeof y !== 'undefined' ? y : x, height)];
+    let [x, y] = tuple;
+    let absoluteX = getAbsoluteValue(x, width);
+    let absoluteY = getAbsoluteValue(typeof y !== 'undefined' ? y : x, height);
+
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/background-position#values
+    // With 3-value syntax, there are two keywords, and an offset that modifies the
+    // preceding keyword
+    if (tuple.length == 3) {
+        // If the first keyword is "left" or "right", we start with the X position
+        if (tuple[0].value == 'left' || tuple[0].value == 'right') {
+            // If the second tuple is an offset, apply it to the X position
+            if (tuple[1].type == TokenType.PERCENTAGE_TOKEN || tuple[1].type == TokenType.DIMENSION_TOKEN) {
+                if (tuple[0].value == 'left') absoluteX = getAbsoluteValue(tuple[1], width);
+                if (tuple[0].value == 'right') absoluteX = width - getAbsoluteValue(tuple[1], width);
+            }
+
+            // If the second tuple is a keyword, X position is left or right
+            if (tuple[1].type == TokenType.IDENT_TOKEN) {
+                if (tuple[0].value == 'left') absoluteX = getAbsoluteValue(tuple[0], width);
+                if (tuple[0].value == 'right') absoluteX = width - getAbsoluteValue(tuple[0], width);
+            }
+
+            // If the first keyword is left/right and the last is 50%, we know that's
+            // vertical centering
+            if (tuple[2].type == TokenType.PERCENTAGE_TOKEN) {
+                absoluteY = getAbsoluteValue(tuple[2], height);
+            }
+        }
+
+        // If the third tuple is an offset (meaning the first two are keywords) it modifies
+        // the second tuple keyword
+        if (tuple[2].type == TokenType.PERCENTAGE_TOKEN || tuple[2].type == TokenType.DIMENSION_TOKEN) {
+            if (tuple[1].value == 'top') absoluteY = getAbsoluteValue(tuple[2], height);
+            if (tuple[1].value == 'bottom') absoluteY = height - getAbsoluteValue(tuple[2], height);
+            if (tuple[1].value == 'left') absoluteX = getAbsoluteValue(tuple[2], width);
+            if (tuple[1].value == 'right') absoluteX = width - getAbsoluteValue(tuple[2], width);
+        }
+
+        // If the first keyword is "center" we check to see if the other keyword is left/right
+        // to see if this applies to Y, otherwise assume X
+        if (tuple[0].value == 'center') {
+            if (
+                tuple[1].value !== 'left' &&
+                tuple[1].value !== 'right' &&
+                tuple[2].value !== 'left' &&
+                tuple[2].value !== 'right'
+            ) {
+                absoluteX = getAbsoluteValue(tuple[0], width);
+            }
+
+            if (tuple[1].value == 'left' || tuple[1].value == 'right') {
+                absoluteY = getAbsoluteValue(tuple[0], height);
+            }
+        }
+
+        if (tuple[1].value == 'center' || tuple[2].value == 'center') {
+            if (tuple[0].value == 'right' || tuple[0].value == 'right') {
+                absoluteY = getAbsoluteValue(tuple[2], height);
+            }
+        }
+    }
+
+    // With 4-value syntax, the 1st and 3rd values are keywords, and the 2nd and 4th
+    // are offsets for each of them respectively
+    if (tuple.length == 4) {
+        if (tuple[0].type == TokenType.IDENT_TOKEN) {
+            if (tuple[0].value == 'left') absoluteX = getAbsoluteValue(tuple[1], width);
+            if (tuple[0].value == 'right') absoluteX = width - getAbsoluteValue(tuple[1], width);
+            if (tuple[0].value == 'top') absoluteY = getAbsoluteValue(tuple[1], height);
+            if (tuple[0].value == 'bottom') absoluteY = height - getAbsoluteValue(tuple[1], height);
+        }
+
+        if (tuple[2].type == TokenType.IDENT_TOKEN) {
+            if (tuple[2].value == 'top') absoluteY = getAbsoluteValue(tuple[3], height);
+            if (tuple[2].value == 'bottom') absoluteY = height - getAbsoluteValue(tuple[3], height);
+            if (tuple[2].value == 'left') absoluteX = getAbsoluteValue(tuple[3], width);
+            if (tuple[2].value == 'right') absoluteX = width - getAbsoluteValue(tuple[3], width);
+        }
+    }
+
+    return [absoluteX, absoluteY];
 };
 export const getAbsoluteValue = (token: LengthPercentage, parent: number): number => {
     if (token.type === TokenType.PERCENTAGE_TOKEN) {
         return (token.number / 100) * parent;
+    }
+
+    if (token.type === TokenType.IDENT_TOKEN) {
+        switch (token.value) {
+            case 'right':
+            case 'bottom':
+                return parent;
+            case 'center':
+                return 0.5 * parent;
+            default:
+                return 0;
+        }
     }
 
     if (isDimensionToken(token)) {

--- a/tests/reftests/background/position.html
+++ b/tests/reftests/background/position.html
@@ -67,7 +67,7 @@
       <div style="background:url(../../assets/image.jpg) no-repeat right 30px bottom 40px;"></div>
       <div style="background:url(../../assets/image.jpg) no-repeat left bottom -40px;"></div>
       <div style="background:url(../../assets/image.jpg) no-repeat right 30% top 20%;"></div>
-      <div style="background:url(../../assets/image.jpg) no-repeat center right 20px;"></div>
+      <div style="background:url(../../assets/image.jpg) no-repeat center right calc(20px + 1em);"></div>
     </div>
 
     <div class="medium">

--- a/tests/reftests/background/position.html
+++ b/tests/reftests/background/position.html
@@ -67,7 +67,7 @@
       <div style="background:url(../../assets/image.jpg) no-repeat right 30px bottom 40px;"></div>
       <div style="background:url(../../assets/image.jpg) no-repeat left bottom -40px;"></div>
       <div style="background:url(../../assets/image.jpg) no-repeat right 30% top 20%;"></div>
-      <div style="background:url(../../assets/image.jpg) no-repeat center right calc(20px + 1em);"></div>
+      <div style="background:url(../../assets/image.jpg) no-repeat right 20px center;"></div>
     </div>
 
     <div class="medium">

--- a/tests/reftests/background/position.html
+++ b/tests/reftests/background/position.html
@@ -27,7 +27,15 @@
         border:1px solid #000;
       }
 
-      .small, .medium{
+      .medium-wide div{
+        width:200px;
+        height:160px;
+        float:left;
+        margin:10px;
+        border:1px solid #000;
+      }
+
+      .small, .medium, .medium-wide{
         clear:both;
       }
 
@@ -53,6 +61,13 @@
       <div style="background:url(../../assets/image.jpg) repeat-x center center;"></div>
       <div style="background:url(../../assets/image.jpg) repeat-y center center;"></div>
       <div style="background:url(../../assets/image.jpg) no-repeat center center;"></div>
+    </div>
+
+    <div class="medium-wide">
+      <div style="background:url(../../assets/image.jpg) no-repeat right 30px bottom 40px;"></div>
+      <div style="background:url(../../assets/image.jpg) no-repeat left bottom -40px;"></div>
+      <div style="background:url(../../assets/image.jpg) no-repeat right 30% top 20%;"></div>
+      <div style="background:url(../../assets/image.jpg) no-repeat center right 20px;"></div>
     </div>
 
     <div class="medium">


### PR DESCRIPTION
**Summary**

Adds support for background-position options that aren't just referenced from the top left corner.

The library supports background positioning based on the top left corner, e.g. `25% 75%`, but does not support referencing the background image location from any other combination of positions, e.g. 'right 15% bottom 12px`.

Notes:
- Modern WebKit browsers pass the keywords (top, left, center, bottom, right) as strings
- Firefox converts positions into calculations when possible, so `right 20px bottom 10%` will become a two-member array with `calc(100% - 20px)` and `calc(100% - 10%)` - I added support for some very basic two-element addition and subtraction calculations to handle this
- Older IE converts positions like `right 20px bottom 10%` into a four-member array with `100%` `-20px` `100%` `-10%`, and gets weird when passing vertical keywords (`top`, `center`, `bottom`), a vertical offset, and then a horizontal position keyword (`left`, `center`, `right`)

**Test plan (required)**

Added four additional cases into `reftests/background/position.html` to test different combinations of top/left/right/center/bottom positioning.

**Closing issues**

Fixes #2801
