### PR TITLE
Add original node name in cloned custom element

### DIFF
--- a/src/dom/document-cloner.ts
+++ b/src/dom/document-cloner.ts
@@ -174,6 +174,7 @@ export class DocumentCloner {
 
     createCustomElementClone(node: HTMLElement): HTMLElement {
         const clone = document.createElement('html2canvascustomelement');
+        clone.setAttribute('html2-canvas-original-tag-name', node.tagName);
         copyCSSStyles(node.style, clone);
 
         return clone;


### PR DESCRIPTION
In 74696fa #2785 you changed the way of how custom-element is copied in the copied document dom

We had some javascript scripts to do some stuff. We need to query over the dom to find some custom elements. This PR is to add the original custom element name as attribute to allow find them.