### PR TITLE
fix: correctly calculate the background repeat path

### DIFF
--- a/src/render/background.ts
+++ b/src/render/background.ts
@@ -226,34 +226,34 @@ export const calculateBackgroundRepeatPath = (
     switch (repeat) {
         case BACKGROUND_REPEAT.REPEAT_X:
             return [
-                new Vector(Math.round(backgroundPositioningArea.left), Math.round(backgroundPositioningArea.top + y)),
+                new Vector(Math.round(backgroundPaintingArea.left), Math.round(backgroundPositioningArea.top + y)),
                 new Vector(
-                    Math.round(backgroundPositioningArea.left + backgroundPositioningArea.width),
+                    Math.round(backgroundPaintingArea.left + backgroundPaintingArea.width),
                     Math.round(backgroundPositioningArea.top + y)
                 ),
                 new Vector(
-                    Math.round(backgroundPositioningArea.left + backgroundPositioningArea.width),
+                    Math.round(backgroundPaintingArea.left + backgroundPaintingArea.width),
                     Math.round(height + backgroundPositioningArea.top + y)
                 ),
                 new Vector(
-                    Math.round(backgroundPositioningArea.left),
+                    Math.round(backgroundPaintingArea.left),
                     Math.round(height + backgroundPositioningArea.top + y)
                 )
             ];
         case BACKGROUND_REPEAT.REPEAT_Y:
             return [
-                new Vector(Math.round(backgroundPositioningArea.left + x), Math.round(backgroundPositioningArea.top)),
+                new Vector(Math.round(backgroundPositioningArea.left + x), Math.round(backgroundPaintingArea.top)),
                 new Vector(
                     Math.round(backgroundPositioningArea.left + x + width),
-                    Math.round(backgroundPositioningArea.top)
+                    Math.round(backgroundPaintingArea.top)
                 ),
                 new Vector(
                     Math.round(backgroundPositioningArea.left + x + width),
-                    Math.round(backgroundPositioningArea.height + backgroundPositioningArea.top)
+                    Math.round(backgroundPaintingArea.height + backgroundPaintingArea.top)
                 ),
                 new Vector(
                     Math.round(backgroundPositioningArea.left + x),
-                    Math.round(backgroundPositioningArea.height + backgroundPositioningArea.top)
+                    Math.round(backgroundPaintingArea.height + backgroundPaintingArea.top)
                 )
             ];
         case BACKGROUND_REPEAT.NO_REPEAT:

--- a/tests/reftests/background/clip-2.html
+++ b/tests/reftests/background/clip-2.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Background attribute tests</title>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <script type="text/javascript" src="../../test.js"></script>
+        <style>
+            html {
+                background-color: red;
+            }
+            body {
+                background-color: lime;
+            }
+
+            .medium div{
+                width:100px;
+                height:100px;
+                float:left;
+                margin:10px;
+                border:20px solid transparent;
+                border-width: 10px 20px 30px 40px;
+                background: green;
+                padding: 25px 15px;
+            }
+
+            .medium{
+                clear:both;
+            }
+
+            div{
+                display:block;
+            }
+
+        </style>
+
+    </head>
+    <body>
+        <div class="medium">
+            <div style="background:url(../../assets/image.jpg);background-clip: border-box; background-origin: padding-box; background-repeat: repeat-x;"></div>
+            <div style="background:url(../../assets/image.jpg);background-clip: padding-box; background-origin: padding-box; background-repeat: repeat-x;"></div>
+            <div style="background:url(../../assets/image.jpg);background-clip: content-box; background-origin: padding-box; background-repeat: repeat-x;"></div>
+            <div style="background:url(../../assets/image.jpg);background-clip: border-box; background-origin: padding-box; background-repeat: repeat;"></div>
+        </div>
+
+        <div class="medium">
+            <div style="background:url(../../assets/image.jpg);background-clip: border-box; background-origin: padding-box; background-repeat: repeat-y;"></div>
+            <div style="background:url(../../assets/image.jpg);background-clip: padding-box; background-origin: padding-box; background-repeat: repeat-y;"></div>
+            <div style="background:url(../../assets/image.jpg);background-clip: content-box; background-origin: padding-box; background-repeat: repeat-y;"></div>
+        </div>
+
+        <div class="medium">
+            <div style="background-clip: border-box;"></div>
+            <div style="background-clip: padding-box;"></div>
+            <div style="background-clip: content-box;"></div>
+            <div style=""></div>
+        </div>
+
+    </body>
+</html>


### PR DESCRIPTION
**Summary**

When using `background-clip` `background-origin` and `background-repeat` at the same time, the calculation of background repeat path may deviate.

<!-- Summary of the PR -->

This PR fixes the following **bug**

* [ ] miscalculate the background repeat path 

 **Explain the motivation**

When we have some code like this：
```
padding: 30px;
background-clip: box-border;
background-origin: padding-box;
background-repeat: repeat-x
```
The background area drawn on the canvas is smaller than that displayed on the actual page：
<img width="549" alt="image" src="https://user-images.githubusercontent.com/22781587/160857560-f96901f1-fbb8-41a6-934a-f5291aa84273.png">
