### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/src/core/cache-storage.ts
+++ b/src/core/cache-storage.ts
@@ -172,6 +172,6 @@ const INLINE_IMG = /^data:image\/.*/i;
 const isRenderable = (src: string): boolean => FEATURES.SUPPORT_SVG_DRAWING || !isSVG(src);
 const isInlineImage = (src: string): boolean => INLINE_IMG.test(src);
 const isInlineBase64Image = (src: string): boolean => INLINE_BASE64.test(src);
-const isBlobImage = (src: string): boolean => src.substr(0, 4) === 'blob';
+const isBlobImage = (src: string): boolean => src.slice(0, 4) === 'blob';
 
-const isSVG = (src: string): boolean => src.substr(-3).toLowerCase() === 'svg' || INLINE_SVG.test(src);
+const isSVG = (src: string): boolean => src.slice(-3).toLowerCase() === 'svg' || INLINE_SVG.test(src);


### PR DESCRIPTION
**Summary**

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

**Test plan (required)**

I tested the return of each statement to make sure it's the same as before

