### PR TITLE
feat: add clip property support

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -24,6 +24,7 @@ Below is a list of all the supported CSS properties and values.
  - box-sizing
  - content
  - color
+ - clip
  - display
  - flex
  - float

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "1.4.0",
+      "name": "html2canvas",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "css-line-break": "^2.1.0",

--- a/src/css/index.ts
+++ b/src/css/index.ts
@@ -30,6 +30,7 @@ import {
     borderRightWidth,
     borderTopWidth
 } from './property-descriptors/border-width';
+import {clip} from './property-descriptors/clip';
 import {color} from './property-descriptors/color';
 import {direction} from './property-descriptors/direction';
 import {display, DISPLAY} from './property-descriptors/display';
@@ -107,6 +108,7 @@ export class CSSParsedDeclaration {
     borderBottomWidth: ReturnType<typeof borderBottomWidth.parse>;
     borderLeftWidth: ReturnType<typeof borderLeftWidth.parse>;
     boxShadow: ReturnType<typeof boxShadow.parse>;
+    clip: ReturnType<typeof clip.parse>;
     color: Color;
     direction: ReturnType<typeof direction.parse>;
     display: ReturnType<typeof display.parse>;
@@ -225,6 +227,12 @@ export class CSSParsedDeclaration {
         this.webkitTextStrokeWidth = parse(context, webkitTextStrokeWidth, declaration.webkitTextStrokeWidth);
         this.wordBreak = parse(context, wordBreak, declaration.wordBreak);
         this.zIndex = parse(context, zIndex, declaration.zIndex);
+
+        if (this.position == POSITION.ABSOLUTE || this.position == POSITION.FIXED) {
+            this.clip = parse(context, clip, declaration.clip);
+        } else {
+            this.clip = null;
+        }
     }
 
     isVisible(): boolean {

--- a/src/css/property-descriptors/clip.ts
+++ b/src/css/property-descriptors/clip.ts
@@ -1,14 +1,17 @@
 import {IPropertyValueDescriptor, PropertyDescriptorParsingType} from '../IPropertyDescriptor';
-import {CSSValue, isDimensionToken, isIdentWithValue, nonFunctionArgSeparator} from '../syntax/parser';
+import {CSSValue, isAutoIdentToken, isDimensionToken} from '../syntax/parser';
 import {Context} from '../../core/context';
-import {DimensionToken, TokenType} from '../syntax/tokenizer';
+import {AutoIdentToken, DimensionToken, TokenType} from '../syntax/tokenizer';
 
 export interface RectClip {
-    top: DimensionToken;
-    right: DimensionToken;
-    bottom: DimensionToken;
-    left: DimensionToken;
+    top: DimensionToken | AutoIdentToken;
+    right: DimensionToken | AutoIdentToken;
+    bottom: DimensionToken | AutoIdentToken;
+    left: DimensionToken | AutoIdentToken;
 }
+
+const isDimensionOrAutoToken = (token: CSSValue): token is DimensionToken | AutoIdentToken =>
+    isDimensionToken(token) || isAutoIdentToken(token);
 
 export const clip: IPropertyValueDescriptor<RectClip | null> = {
     name: 'clip',
@@ -16,16 +19,16 @@ export const clip: IPropertyValueDescriptor<RectClip | null> = {
     type: PropertyDescriptorParsingType.VALUE,
     prefix: false,
     parse: (_context: Context, token: CSSValue) => {
-        if (isIdentWithValue(token, 'auto')) {
+        if (isAutoIdentToken(token)) {
             return null;
         }
         if (token.type !== TokenType.FUNCTION || token.name !== 'rect') {
             throw new Error('Clip value must be auto or a rect function');
         }
 
-        const rectArgs = token.values.filter(nonFunctionArgSeparator).filter(isDimensionToken);
+        const rectArgs = token.values.filter(isDimensionOrAutoToken);
         if (rectArgs.length !== 4) {
-            throw new Error('Rect clip must have 4 dimension elements');
+            throw new Error('Rect clip must have 4 elements that are either a dimension or "auto"');
         }
 
         return {

--- a/src/css/property-descriptors/clip.ts
+++ b/src/css/property-descriptors/clip.ts
@@ -1,0 +1,38 @@
+import {IPropertyValueDescriptor, PropertyDescriptorParsingType} from '../IPropertyDescriptor';
+import {CSSValue, isDimensionToken, isIdentWithValue, nonFunctionArgSeparator} from '../syntax/parser';
+import {Context} from '../../core/context';
+import {DimensionToken, TokenType} from '../syntax/tokenizer';
+
+export interface RectClip {
+    top: DimensionToken;
+    right: DimensionToken;
+    bottom: DimensionToken;
+    left: DimensionToken;
+}
+
+export const clip: IPropertyValueDescriptor<RectClip | null> = {
+    name: 'clip',
+    initialValue: 'auto',
+    type: PropertyDescriptorParsingType.VALUE,
+    prefix: false,
+    parse: (_context: Context, token: CSSValue) => {
+        if (isIdentWithValue(token, 'auto')) {
+            return null;
+        }
+        if (token.type !== TokenType.FUNCTION || token.name !== 'rect') {
+            throw new Error('Clip value must be auto or a rect function');
+        }
+
+        const rectArgs = token.values.filter(nonFunctionArgSeparator).filter(isDimensionToken);
+        if (rectArgs.length !== 4) {
+            throw new Error('Rect clip must have 4 dimension elements');
+        }
+
+        return {
+            top: rectArgs[0],
+            right: rectArgs[1],
+            bottom: rectArgs[2],
+            left: rectArgs[3]
+        };
+    }
+};

--- a/src/css/syntax/parser.ts
+++ b/src/css/syntax/parser.ts
@@ -1,4 +1,5 @@
 import {
+    AutoIdentToken,
     CSSToken,
     DimensionToken,
     EOF_TOKEN,
@@ -145,6 +146,7 @@ export const isDimensionToken = (token: CSSValue): token is DimensionToken => to
 export const isNumberToken = (token: CSSValue): token is NumberValueToken => token.type === TokenType.NUMBER_TOKEN;
 export const isIdentToken = (token: CSSValue): token is StringValueToken => token.type === TokenType.IDENT_TOKEN;
 export const isStringToken = (token: CSSValue): token is StringValueToken => token.type === TokenType.STRING_TOKEN;
+export const isAutoIdentToken = (token: CSSValue): token is AutoIdentToken => isIdentWithValue(token, 'auto');
 export const isIdentWithValue = (token: CSSValue, value: string): boolean =>
     isIdentToken(token) && token.value === value;
 

--- a/src/css/syntax/tokenizer.ts
+++ b/src/css/syntax/tokenizer.ts
@@ -97,6 +97,11 @@ export interface DimensionToken extends IToken {
     number: number;
 }
 
+export interface AutoIdentToken extends IToken {
+    type: TokenType.IDENT_TOKEN;
+    value: 'auto';
+}
+
 export interface UnicodeRangeToken extends IToken {
     type: TokenType.UNICODE_RANGE_TOKEN;
     start: number;

--- a/src/css/types/length-percentage.ts
+++ b/src/css/types/length-percentage.ts
@@ -40,15 +40,18 @@ export const getAbsoluteValue = (token: LengthPercentage, parent: number): numbe
     }
 
     if (isDimensionToken(token)) {
-        switch (token.unit) {
-            case 'rem':
-            case 'em':
-                return 16 * token.number; // TODO use correct font-size
-            case 'px':
-            default:
-                return token.number;
-        }
+        return getAbsoluteValueForDimension(token);
     }
 
     return token.number;
+};
+export const getAbsoluteValueForDimension = (token: DimensionToken): number => {
+    switch (token.unit) {
+        case 'rem':
+        case 'em':
+            return 16 * token.number; // TODO use correct font-size
+        case 'px':
+        default:
+            return token.number;
+    }
 };

--- a/src/render/bound-curves.ts
+++ b/src/render/bound-curves.ts
@@ -1,8 +1,9 @@
 import {ElementContainer} from '../dom/element-container';
-import {getAbsoluteValue, getAbsoluteValueForTuple, getAbsoluteValueForDimension} from '../css/types/length-percentage';
+import {getAbsoluteValue, getAbsoluteValueForDimension, getAbsoluteValueForTuple} from '../css/types/length-percentage';
 import {Vector} from './vector';
 import {BezierCurve} from './bezier-curve';
 import {Path} from './path';
+import {TokenType} from '../css/syntax/tokenizer';
 
 export class BoundCurves {
     readonly topLeftBorderDoubleOuterBox: Path;
@@ -76,16 +77,19 @@ export class BoundCurves {
         const paddingBottom = getAbsoluteValue(styles.paddingBottom, element.bounds.width);
         const paddingLeft = getAbsoluteValue(styles.paddingLeft, element.bounds.width);
 
-        let rectClipTop = 0;
-        let rectClipRight = 0;
-        let rectClipBottom = 0;
-        let rectClipLeft = 0;
-        if (styles.clip) {
-            rectClipTop = getAbsoluteValueForDimension(styles.clip.top);
-            rectClipRight = getAbsoluteValueForDimension(styles.clip.right);
-            rectClipBottom = getAbsoluteValueForDimension(styles.clip.bottom);
-            rectClipLeft = getAbsoluteValueForDimension(styles.clip.left);
-        }
+        const rectClipTop =
+            styles.clip?.top.type == TokenType.DIMENSION_TOKEN ? getAbsoluteValueForDimension(styles.clip.top) : 0;
+        const rectClipLeft =
+            styles.clip?.left.type == TokenType.DIMENSION_TOKEN ? getAbsoluteValueForDimension(styles.clip.left) : 0;
+
+        const rectClipBottom =
+            styles.clip?.bottom.type == TokenType.DIMENSION_TOKEN
+                ? getAbsoluteValueForDimension(styles.clip.bottom)
+                : bounds.height;
+        const rectClipRight =
+            styles.clip?.right.type == TokenType.DIMENSION_TOKEN
+                ? getAbsoluteValueForDimension(styles.clip.right)
+                : bounds.width;
 
         this.topLeftBorderDoubleOuterBox =
             tlh > 0 || tlv > 0

--- a/src/render/bound-curves.ts
+++ b/src/render/bound-curves.ts
@@ -1,5 +1,5 @@
 import {ElementContainer} from '../dom/element-container';
-import {getAbsoluteValue, getAbsoluteValueForTuple} from '../css/types/length-percentage';
+import {getAbsoluteValue, getAbsoluteValueForTuple, getAbsoluteValueForDimension} from '../css/types/length-percentage';
 import {Vector} from './vector';
 import {BezierCurve} from './bezier-curve';
 import {Path} from './path';
@@ -21,6 +21,10 @@ export class BoundCurves {
     readonly topRightBorderBox: Path;
     readonly bottomRightBorderBox: Path;
     readonly bottomLeftBorderBox: Path;
+    readonly topLeftClipBox: Path;
+    readonly topRightClipBox: Path;
+    readonly bottomRightClipBox: Path;
+    readonly bottomLeftClipBox: Path;
     readonly topLeftPaddingBox: Path;
     readonly topRightPaddingBox: Path;
     readonly bottomRightPaddingBox: Path;
@@ -71,6 +75,17 @@ export class BoundCurves {
         const paddingRight = getAbsoluteValue(styles.paddingRight, element.bounds.width);
         const paddingBottom = getAbsoluteValue(styles.paddingBottom, element.bounds.width);
         const paddingLeft = getAbsoluteValue(styles.paddingLeft, element.bounds.width);
+
+        let rectClipTop = 0;
+        let rectClipRight = 0;
+        let rectClipBottom = 0;
+        let rectClipLeft = 0;
+        if (styles.clip) {
+            rectClipTop = getAbsoluteValueForDimension(styles.clip.top);
+            rectClipRight = getAbsoluteValueForDimension(styles.clip.right);
+            rectClipBottom = getAbsoluteValueForDimension(styles.clip.bottom);
+            rectClipLeft = getAbsoluteValueForDimension(styles.clip.left);
+        }
 
         this.topLeftBorderDoubleOuterBox =
             tlh > 0 || tlv > 0
@@ -223,6 +238,10 @@ export class BoundCurves {
             blh > 0 || blv > 0
                 ? getCurvePoints(bounds.left, bounds.top + leftHeight, blh, blv, CORNER.BOTTOM_LEFT)
                 : new Vector(bounds.left, bounds.top + bounds.height);
+        this.topLeftClipBox = new Vector(bounds.left + rectClipLeft, bounds.top + rectClipTop);
+        this.topRightClipBox = new Vector(bounds.left + rectClipRight, bounds.top + rectClipTop);
+        this.bottomRightClipBox = new Vector(bounds.left + rectClipRight, bounds.top + rectClipBottom);
+        this.bottomLeftClipBox = new Vector(bounds.left + rectClipLeft, bounds.top + rectClipBottom);
         this.topLeftPaddingBox =
             tlh > 0 || tlv > 0
                 ? getCurvePoints(
@@ -367,6 +386,10 @@ const getCurvePoints = (x: number, y: number, r1: number, r2: number, position: 
 
 export const calculateBorderBoxPath = (curves: BoundCurves): Path[] => {
     return [curves.topLeftBorderBox, curves.topRightBorderBox, curves.bottomRightBorderBox, curves.bottomLeftBorderBox];
+};
+
+export const calculateRectClipPath = (curves: BoundCurves): Path[] => {
+    return [curves.topLeftClipBox, curves.topRightClipBox, curves.bottomRightClipBox, curves.bottomLeftClipBox];
 };
 
 export const calculateContentBoxPath = (curves: BoundCurves): Path[] => {

--- a/src/render/stacking-context.ts
+++ b/src/render/stacking-context.ts
@@ -1,6 +1,6 @@
 import {ElementContainer, FLAGS} from '../dom/element-container';
 import {contains} from '../core/bitwise';
-import {BoundCurves, calculateBorderBoxPath, calculatePaddingBoxPath} from './bound-curves';
+import {BoundCurves, calculateBorderBoxPath, calculatePaddingBoxPath, calculateRectClipPath} from './bound-curves';
 import {ClipEffect, EffectTarget, IElementEffect, isClipEffect, OpacityEffect, TransformEffect} from './effects';
 import {OVERFLOW} from '../css/property-descriptors/overflow';
 import {equalPath} from './path';
@@ -61,6 +61,12 @@ export class ElementPaint {
                 this.effects.push(new ClipEffect(paddingBox, EffectTarget.CONTENT));
             }
         }
+
+        if (this.container.styles.clip) {
+            const clipBox = calculateRectClipPath(this.curves);
+            const clipEffect = new ClipEffect(clipBox, EffectTarget.BACKGROUND_BORDERS | EffectTarget.CONTENT);
+            this.effects.push(clipEffect);
+        }
     }
 
     getEffects(target: EffectTarget): IElementEffect[] {
@@ -80,6 +86,11 @@ export class ElementPaint {
                             new ClipEffect(paddingBox, EffectTarget.BACKGROUND_BORDERS | EffectTarget.CONTENT)
                         );
                     }
+                }
+                if (parent.container.styles.clip) {
+                    const clipBox = calculateRectClipPath(parent.curves);
+                    const clipEffect = new ClipEffect(clipBox, EffectTarget.BACKGROUND_BORDERS | EffectTarget.CONTENT);
+                    effects.unshift(clipEffect);
                 }
             } else {
                 effects.unshift(...croplessEffects);

--- a/tests/reftests/clip.html
+++ b/tests/reftests/clip.html
@@ -45,5 +45,13 @@
 <div style="clip: rect(0px, 400px, 50px, 200px); position: absolute; top: 500px; left: 500px; border-radius: 100%; overflow: hidden;">Some inline text <span> followed by text in span </span> followed by more inline text.
     <p>Then a block level element.</p>
     Then more inline text.</div>
+
+<div style="clip: rect(auto, auto, auto, 30px); position: absolute; top: 750px;">Some inline text <span> followed by text in span </span> followed by more inline text.
+    <p>Then a block level element.</p>
+    Then more inline text.</div>
+
+<div style="clip: auto; position: absolute; top: 750px; left: 500px;">Some inline text <span> followed by text in span </span> followed by more inline text.
+    <p>Then a block level element.</p>
+    Then more inline text.</div>
 </body>
 </html>

--- a/tests/reftests/clip.html
+++ b/tests/reftests/clip.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>Inline text in the top element</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
@@ -16,7 +16,7 @@
             border: 5px solid blue;
         }
         body {
-            font-family: Arial;
+            font-family: Arial, sans-serif;
         }
     </style>
 
@@ -37,9 +37,12 @@
 <div style="clip: rect(0px, 400px, 50px, 200px); position: absolute; top: 250px; left: 500px;">Some inline text <span> followed by text in span </span> followed by more inline text.
     <p>Then a block level element.</p>
     Then more inline text.</div>
-</body>
 
 <div style="clip: rect(0px, 400px, 50px, 200px); position: absolute; top: 500px;">Some inline text <span> followed by text in span </span> followed by more inline text.
+    <p>Then a block level element.</p>
+    Then more inline text.</div>
+
+<div style="clip: rect(0px, 400px, 50px, 200px); position: absolute; top: 500px; left: 500px; border-radius: 100%; overflow: hidden;">Some inline text <span> followed by text in span </span> followed by more inline text.
     <p>Then a block level element.</p>
     Then more inline text.</div>
 </body>


### PR DESCRIPTION
## **Summary**

This PR fixes/implements the following **bugs/features**

* Adds support for `clip`

clip.html has been present in reftests, but did not work. I'll follow this up in the coming weeks with a PR for the newer `clip-path` attribute as well :grin:

## **Test plan (required)**

`clip.html` in reftests, with additional testing to make sure it works in conjunction with overflow clipping effects

## **Code formatting**

✅ 

## **Closing issues**

N/A
