### PR TITLE
fix renderBackgroundImage When receiving an image with 0 width or height

### DIFF
--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -595,10 +595,13 @@ export class CanvasRenderer extends Renderer {
                 }
 
                 if (image) {
+                    let widthTmp = Math.max(1, image.width);
+                    let heightTmp = Math.max(1, image.height);
+
                     const [path, x, y, width, height] = calculateBackgroundRendering(container, index, [
-                        image.width,
-                        image.height,
-                        image.width / image.height
+                        widthTmp,
+                        heightTmp,
+                        widthTmp / heightTmp
                     ]);
                     const pattern = this.ctx.createPattern(
                         this.resizeImage(image, width, height),

--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -595,13 +595,10 @@ export class CanvasRenderer extends Renderer {
                 }
 
                 if (image) {
-                    let widthTmp = Math.max(1, image.width);
-                    let heightTmp = Math.max(1, image.height);
-
                     const [path, x, y, width, height] = calculateBackgroundRendering(container, index, [
-                        widthTmp,
-                        heightTmp,
-                        widthTmp / heightTmp
+                        image.width,
+                        image.height,
+                        image.width / image.height
                     ]);
                     const pattern = this.ctx.createPattern(
                         this.resizeImage(image, width, height),
@@ -614,8 +611,8 @@ export class CanvasRenderer extends Renderer {
                 const [lineLength, x0, x1, y0, y1] = calculateGradientDirection(backgroundImage.angle, width, height);
 
                 const canvas = document.createElement('canvas');
-                canvas.width = width;
-                canvas.height = height;
+                canvas.width = Math.max(1, width);
+                canvas.height = Math.max(1, height);
                 const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
                 const gradient = ctx.createLinearGradient(x0, y0, x1, y1);
 


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ ] Fixed bug in background when receiving an image with 0 width or height

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

I get the following error when user zoom in some pages.

![image](https://user-images.githubusercontent.com/6630197/171805622-454b45a8-a57c-4562-bf5d-86f64e54b19e.png)

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

This bug is a little tricky to reproduce. It happens when user zoom in the browser and it only happens in some pages (i don't know that element html produces the error).

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #2807

**Notes** : this pr is similar to https://github.com/niklasvh/html2canvas/pull/2409/files#diff-d002d2a3a6a450c487065f80a86beb8070d226d4608ba1c42d468148ad9c24fe