### PR TITLE
fix: Operation is insecure on safari (#2688)

### DIFF
--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -569,9 +569,10 @@ export class CanvasRenderer extends Renderer {
     }
 
     resizeImage(image: HTMLImageElement, width: number, height: number): HTMLCanvasElement | HTMLImageElement {
-        if (image.width === width && image.height === height) {
-            return image;
-        }
+
+        // if (image.width === width && image.height === height) {
+        //     return image;
+        // }
 
         const ownerDocument = this.canvas.ownerDocument ?? document;
         const canvas = ownerDocument.createElement('canvas');


### PR DESCRIPTION
Fixes : Operation is insecure on safari
Problem : Using background image causes the issue ( note: it can have data uri or image binded to it which is not a concern)
Solution : When we use background image , resizeImage function returns an image to create pattern on canvas, however createPattern method does not work properly with images (especially when it's svg ) , so to resolve this we can pass canvas to the createPattern, which means resizeImage always needs to return a canvas on which the required image is drawn already !

Fixes Issue : #2688 