### PR TITLE
Update canvas-renderer.ts to fix Vertical alignment issues with text

### DIFF
--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -146,12 +146,11 @@ export class CanvasRenderer extends Renderer {
 
     renderTextWithLetterSpacing(text: TextBounds, letterSpacing: number, baseline: number): void {
         if (letterSpacing === 0) {
-            this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + baseline);
+            this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + text.bounds.height - baseline);
         } else {
             const letters = segmentGraphemes(text.text);
             letters.reduce((left, letter) => {
-                this.ctx.fillText(letter, left, text.bounds.top + baseline);
-
+                this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + text.bounds.height - baseline);
                 return left + this.ctx.measureText(letter).width;
             }, text.bounds.left);
         }


### PR DESCRIPTION
- Bug 1 Fixes vertical alignment of text within divs - issue shown here: https://github.com/niklasvh/html2canvas/issues/2937

- Now the fillText usage logically makes sense

- Tested across Chrome, Firefox, Safari

Before:
![1660838787558](https://user-images.githubusercontent.com/10956482/185445883-2818baf9-eedb-4479-8304-9dd3c4144492.png)

After:
![1660838848709](https://user-images.githubusercontent.com/10956482/185445936-44cc9d3f-4cee-40e6-a217-5e8720722b1a.png)
