### PR TITLE
Cleanup iframe first to prevent memory leaks, see #1609

### DIFF
--- a/src/dom/document-cloner.ts
+++ b/src/dom/document-cloner.ts
@@ -480,15 +480,15 @@ export class DocumentCloner {
 
     static destroy(container: HTMLIFrameElement): boolean {
         // cleanup iframe first to prevent memory leaks, see #1609
-        try{
-            const iframe=container.contentWindow;
-            container.src='about:blank';
-            if(iframe) {
+        try {
+            const iframe = container.contentWindow;
+            container.src = 'about:blank';
+            if (iframe) {
                 iframe.document.write('');
                 iframe.document.clear();
                 iframe.close();
             }
-        }catch {}
+        } catch {}
         if (container.parentNode) {
             container.parentNode.removeChild(container);
             return true;

--- a/src/dom/document-cloner.ts
+++ b/src/dom/document-cloner.ts
@@ -479,6 +479,16 @@ export class DocumentCloner {
     }
 
     static destroy(container: HTMLIFrameElement): boolean {
+        // cleanup iframe first to prevent memory leaks, see #1609
+        try{
+            const iframe=container.contentWindow;
+            container.src='about:blank';
+            if(iframe) {
+                iframe.document.write('');
+                iframe.document.clear();
+                iframe.close();
+            }
+        }catch {}
         if (container.parentNode) {
             container.parentNode.removeChild(container);
             return true;


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] Fixed memory leaks caused by cloned iframe's detached window

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

I'm working on a PNG sequence rendering project, and I was trying to use this for lightweight rendering (heavyweight ones should use headless chrome based project like Remotion)

About 200 frames can be rendered well, and then the page got out ouf memory and crashed.

With a heap snapshot, it is clear that "Detached window" consumes most of the memory.

Tried to clean up iframes and remove it manually in the promise resolve, it works very well, the memory usage of Chrome barely increases after that, and I can render 2000+ frames at once. 

See #1609 for the detailed cleanup code.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

You may need a heavy dom tree with some datasrc images to speedup the memory leaks.
Then, call html2canvas repeatedly, monitor Chrome's memory usage in taskmgr, or until it crashes.

**Code formatting**

Please make sure that code adheres to the project code formatting. Running `npm run format` will automatically format your code correctly.

Sure.

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #1609 
