### PR TITLE
Fix issue #2739 allow for multiple bounding boxes in an element.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "1.4.0",
+      "name": "html2canvas",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "css-line-break": "^2.1.0",

--- a/src/css/layout/__mocks__/bounds.ts
+++ b/src/css/layout/__mocks__/bounds.ts
@@ -1,4 +1,4 @@
 export const {Bounds} = jest.requireActual('../bounds');
-export const parseBounds = (): typeof Bounds => {
-    return new Bounds(0, 0, 200, 50);
+export const parseBounds = (): typeof Bounds[] => {
+    return [new Bounds(0, 0, 200, 50)];
 };

--- a/src/css/layout/__mocks__/bounds.ts
+++ b/src/css/layout/__mocks__/bounds.ts
@@ -2,3 +2,7 @@ export const {Bounds} = jest.requireActual('../bounds');
 export const parseBounds = (): typeof Bounds[] => {
     return [new Bounds(0, 0, 200, 50)];
 };
+
+export const parseBound = (): typeof Bounds => {
+    return new Bounds(0, 0, 200, 50);
+};

--- a/src/css/layout/bounds.ts
+++ b/src/css/layout/bounds.ts
@@ -7,17 +7,19 @@ export class Bounds {
         return new Bounds(this.left + x, this.top + y, this.width + w, this.height + h);
     }
 
-    static fromClientRect(context: Context, clientRect: ClientRect): Bounds {
-        return new Bounds(
-            clientRect.left + context.windowBounds.left,
-            clientRect.top + context.windowBounds.top,
-            clientRect.width,
-            clientRect.height
-        );
+    static fromDomRect(context: Context, domRect: DOMRect): Bounds {
+        return domRect.width !== 0 && domRect.height !== 0
+            ? new Bounds(
+                  domRect.left + context.windowBounds.left,
+                  domRect.top + context.windowBounds.top,
+                  domRect.width,
+                  domRect.height
+              )
+            : Bounds.EMPTY;
     }
 
     static fromDOMRectList(context: Context, domRectList: DOMRectList): Bounds {
-        const domRect = Array.from(domRectList).find((rect) => rect.width !== 0);
+        const domRect = Array.from(domRectList).find((rect) => rect.width !== 0 && rect.height !== 0);
         return domRect
             ? new Bounds(
                   domRect.left + context.windowBounds.left,
@@ -30,9 +32,12 @@ export class Bounds {
 
     static EMPTY = new Bounds(0, 0, 0, 0);
 }
+export const parseBound = (context: Context, node: Element): Bounds => {
+    return Bounds.fromDomRect(context, node.getBoundingClientRect());
+};
 
-export const parseBounds = (context: Context, node: Element): Bounds => {
-    return Bounds.fromClientRect(context, node.getBoundingClientRect());
+export const parseBounds = (context: Context, node: Element): Bounds[] => {
+    return Array.from(node.getClientRects()).map((b) => Bounds.fromDomRect(context, b));
 };
 
 export const parseDocumentSize = (document: Document): Bounds => {

--- a/src/css/layout/text.ts
+++ b/src/css/layout/text.ts
@@ -49,7 +49,9 @@ export const parseTextBounds = (
                 }
             } else {
                 const replacementNode = node.splitText(text.length);
-                textBounds.push(new TextBounds(text, getWrapperBounds(context, node)));
+                getWrapperBounds(context, node).forEach((wrapperBound) => {
+                    textBounds.push(new TextBounds(text, wrapperBound));
+                });
                 node = replacementNode;
             }
         } else if (!FEATURES.SUPPORT_RANGE_BOUNDS) {
@@ -61,7 +63,7 @@ export const parseTextBounds = (
     return textBounds;
 };
 
-const getWrapperBounds = (context: Context, node: Text): Bounds => {
+const getWrapperBounds = (context: Context, node: Text): Bounds[] => {
     const ownerDocument = node.ownerDocument;
     if (ownerDocument) {
         const wrapper = ownerDocument.createElement('html2canvaswrapper');
@@ -77,7 +79,7 @@ const getWrapperBounds = (context: Context, node: Text): Bounds => {
         }
     }
 
-    return Bounds.EMPTY;
+    return [Bounds.EMPTY];
 };
 
 const createRange = (node: Text, offset: number, length: number): Range => {

--- a/src/dom/element-container.ts
+++ b/src/dom/element-container.ts
@@ -16,7 +16,7 @@ export class ElementContainer {
     readonly styles: CSSParsedDeclaration;
     readonly textNodes: TextContainer[] = [];
     readonly elements: ElementContainer[] = [];
-    bounds: Bounds;
+    bounds: Bounds[];
     flags = 0;
 
     constructor(protected readonly context: Context, element: Element) {

--- a/src/dom/replaced-elements/input-element-container.ts
+++ b/src/dom/replaced-elements/input-element-container.ts
@@ -74,7 +74,7 @@ export class InputElementContainer extends ElementContainer {
                     BORDER_STYLE.SOLID;
             this.styles.backgroundClip = [BACKGROUND_CLIP.BORDER_BOX];
             this.styles.backgroundOrigin = [BACKGROUND_ORIGIN.BORDER_BOX];
-            this.bounds = reformatInputBounds(this.bounds);
+            this.bounds = this.bounds.map(reformatInputBounds);
         }
 
         switch (this.type) {

--- a/src/dom/replaced-elements/svg-element-container.ts
+++ b/src/dom/replaced-elements/svg-element-container.ts
@@ -1,5 +1,5 @@
 import {ElementContainer} from '../element-container';
-import {parseBounds} from '../../css/layout/bounds';
+import {parseBound} from '../../css/layout/bounds';
 import {Context} from '../../core/context';
 
 export class SVGElementContainer extends ElementContainer {
@@ -10,7 +10,7 @@ export class SVGElementContainer extends ElementContainer {
     constructor(context: Context, img: SVGSVGElement) {
         super(context, img);
         const s = new XMLSerializer();
-        const bounds = parseBounds(context, img);
+        const bounds = parseBound(context, img);
         img.setAttribute('width', `${bounds.width}px`);
         img.setAttribute('height', `${bounds.height}px`);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {Bounds, parseBounds, parseDocumentSize} from './css/layout/bounds';
+import {Bounds, parseBound, parseDocumentSize} from './css/layout/bounds';
 import {COLORS, isTransparent, parseColor} from './css/types/color';
 import {CloneConfigurations, CloneOptions, DocumentCloner, WindowOptions} from './dom/document-cloner';
 import {isBodyElement, isHTMLElement, parseTree} from './dom/node-parser';
@@ -98,7 +98,7 @@ const renderElement = async (element: HTMLElement, opts: Partial<Options>): Prom
     const {width, height, left, top} =
         isBodyElement(clonedElement) || isHTMLElement(clonedElement)
             ? parseDocumentSize(clonedElement.ownerDocument)
-            : parseBounds(context, clonedElement);
+            : parseBound(context, clonedElement);
 
     const backgroundColor = parseBackgroundColor(context, clonedElement, opts.backgroundColor);
 

--- a/src/render/border.ts
+++ b/src/render/border.ts
@@ -2,30 +2,36 @@ import {Path} from './path';
 import {BoundCurves} from './bound-curves';
 import {isBezierCurve} from './bezier-curve';
 
-export const parsePathForBorder = (curves: BoundCurves, borderSide: number): Path[] => {
+export enum BORDER_SIDE {
+    TOP = 0,
+    RIGHT = 1,
+    BOTTOM = 2,
+    LEFT = 3
+}
+export const parsePathForBorder = (curves: BoundCurves, borderSide: BORDER_SIDE): Path[] => {
     switch (borderSide) {
-        case 0:
+        case BORDER_SIDE.TOP:
             return createPathFromCurves(
                 curves.topLeftBorderBox,
                 curves.topLeftPaddingBox,
                 curves.topRightBorderBox,
                 curves.topRightPaddingBox
             );
-        case 1:
+        case BORDER_SIDE.RIGHT:
             return createPathFromCurves(
                 curves.topRightBorderBox,
                 curves.topRightPaddingBox,
                 curves.bottomRightBorderBox,
                 curves.bottomRightPaddingBox
             );
-        case 2:
+        case BORDER_SIDE.BOTTOM:
             return createPathFromCurves(
                 curves.bottomRightBorderBox,
                 curves.bottomRightPaddingBox,
                 curves.bottomLeftBorderBox,
                 curves.bottomLeftPaddingBox
             );
-        case 3:
+        case BORDER_SIDE.LEFT:
         default:
             return createPathFromCurves(
                 curves.bottomLeftBorderBox,
@@ -36,30 +42,30 @@ export const parsePathForBorder = (curves: BoundCurves, borderSide: number): Pat
     }
 };
 
-export const parsePathForBorderDoubleOuter = (curves: BoundCurves, borderSide: number): Path[] => {
+export const parsePathForBorderDoubleOuter = (curves: BoundCurves, borderSide: BORDER_SIDE): Path[] => {
     switch (borderSide) {
-        case 0:
+        case BORDER_SIDE.TOP:
             return createPathFromCurves(
                 curves.topLeftBorderBox,
                 curves.topLeftBorderDoubleOuterBox,
                 curves.topRightBorderBox,
                 curves.topRightBorderDoubleOuterBox
             );
-        case 1:
+        case BORDER_SIDE.RIGHT:
             return createPathFromCurves(
                 curves.topRightBorderBox,
                 curves.topRightBorderDoubleOuterBox,
                 curves.bottomRightBorderBox,
                 curves.bottomRightBorderDoubleOuterBox
             );
-        case 2:
+        case BORDER_SIDE.BOTTOM:
             return createPathFromCurves(
                 curves.bottomRightBorderBox,
                 curves.bottomRightBorderDoubleOuterBox,
                 curves.bottomLeftBorderBox,
                 curves.bottomLeftBorderDoubleOuterBox
             );
-        case 3:
+        case BORDER_SIDE.LEFT:
         default:
             return createPathFromCurves(
                 curves.bottomLeftBorderBox,
@@ -70,30 +76,30 @@ export const parsePathForBorderDoubleOuter = (curves: BoundCurves, borderSide: n
     }
 };
 
-export const parsePathForBorderDoubleInner = (curves: BoundCurves, borderSide: number): Path[] => {
+export const parsePathForBorderDoubleInner = (curves: BoundCurves, borderSide: BORDER_SIDE): Path[] => {
     switch (borderSide) {
-        case 0:
+        case BORDER_SIDE.TOP:
             return createPathFromCurves(
                 curves.topLeftBorderDoubleInnerBox,
                 curves.topLeftPaddingBox,
                 curves.topRightBorderDoubleInnerBox,
                 curves.topRightPaddingBox
             );
-        case 1:
+        case BORDER_SIDE.RIGHT:
             return createPathFromCurves(
                 curves.topRightBorderDoubleInnerBox,
                 curves.topRightPaddingBox,
                 curves.bottomRightBorderDoubleInnerBox,
                 curves.bottomRightPaddingBox
             );
-        case 2:
+        case BORDER_SIDE.BOTTOM:
             return createPathFromCurves(
                 curves.bottomRightBorderDoubleInnerBox,
                 curves.bottomRightPaddingBox,
                 curves.bottomLeftBorderDoubleInnerBox,
                 curves.bottomLeftPaddingBox
             );
-        case 3:
+        case BORDER_SIDE.LEFT:
         default:
             return createPathFromCurves(
                 curves.bottomLeftBorderDoubleInnerBox,
@@ -104,15 +110,15 @@ export const parsePathForBorderDoubleInner = (curves: BoundCurves, borderSide: n
     }
 };
 
-export const parsePathForBorderStroke = (curves: BoundCurves, borderSide: number): Path[] => {
+export const parsePathForBorderStroke = (curves: BoundCurves, borderSide: BORDER_SIDE): Path[] => {
     switch (borderSide) {
-        case 0:
+        case BORDER_SIDE.TOP:
             return createStrokePathFromCurves(curves.topLeftBorderStroke, curves.topRightBorderStroke);
-        case 1:
+        case BORDER_SIDE.RIGHT:
             return createStrokePathFromCurves(curves.topRightBorderStroke, curves.bottomRightBorderStroke);
-        case 2:
+        case BORDER_SIDE.BOTTOM:
             return createStrokePathFromCurves(curves.bottomRightBorderStroke, curves.bottomLeftBorderStroke);
-        case 3:
+        case BORDER_SIDE.LEFT:
         default:
             return createStrokePathFromCurves(curves.bottomLeftBorderStroke, curves.topLeftBorderStroke);
     }

--- a/src/render/box-sizing.ts
+++ b/src/render/box-sizing.ts
@@ -2,30 +2,30 @@ import {getAbsoluteValue} from '../css/types/length-percentage';
 import {Bounds} from '../css/layout/bounds';
 import {ElementContainer} from '../dom/element-container';
 
-export const paddingBox = (element: ElementContainer): Bounds => {
-    const bounds = element.bounds;
+export const paddingBox = (element: ElementContainer): Bounds[] => {
     const styles = element.styles;
-    return bounds.add(
-        styles.borderLeftWidth,
-        styles.borderTopWidth,
-        -(styles.borderRightWidth + styles.borderLeftWidth),
-        -(styles.borderTopWidth + styles.borderBottomWidth)
-    );
+    return element.bounds.map((bound) => {
+        return bound.add(
+            styles.borderLeftWidth,
+            styles.borderTopWidth,
+            -(styles.borderRightWidth + styles.borderLeftWidth),
+            -(styles.borderTopWidth + styles.borderBottomWidth)
+        );
+    });
 };
 
-export const contentBox = (element: ElementContainer): Bounds => {
+export const contentBox = (element: ElementContainer): Bounds[] => {
     const styles = element.styles;
-    const bounds = element.bounds;
-
-    const paddingLeft = getAbsoluteValue(styles.paddingLeft, bounds.width);
-    const paddingRight = getAbsoluteValue(styles.paddingRight, bounds.width);
-    const paddingTop = getAbsoluteValue(styles.paddingTop, bounds.width);
-    const paddingBottom = getAbsoluteValue(styles.paddingBottom, bounds.width);
-
-    return bounds.add(
-        paddingLeft + styles.borderLeftWidth,
-        paddingTop + styles.borderTopWidth,
-        -(styles.borderRightWidth + styles.borderLeftWidth + paddingLeft + paddingRight),
-        -(styles.borderTopWidth + styles.borderBottomWidth + paddingTop + paddingBottom)
-    );
+    return element.bounds.map((bound) => {
+        const paddingLeft = getAbsoluteValue(styles.paddingLeft, bound.width);
+        const paddingRight = getAbsoluteValue(styles.paddingRight, bound.width);
+        const paddingTop = getAbsoluteValue(styles.paddingTop, bound.width);
+        const paddingBottom = getAbsoluteValue(styles.paddingBottom, bound.width);
+        return bound.add(
+            paddingLeft + styles.borderLeftWidth,
+            paddingTop + styles.borderTopWidth,
+            -(styles.borderRightWidth + styles.borderLeftWidth + paddingLeft + paddingRight),
+            -(styles.borderTopWidth + styles.borderBottomWidth + paddingTop + paddingBottom)
+        );
+    });
 };

--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -617,11 +617,13 @@ export class CanvasRenderer extends Renderer {
                     ]);
                     areas.forEach((area) => {
                         const [path, x, y, width, height] = area;
-                        const pattern = this.ctx.createPattern(
-                            this.resizeImage(image!, width, height),
-                            'repeat'
-                        ) as CanvasPattern;
-                        this.renderRepeat(path, pattern, x, y);
+                        if (image) {
+                            const pattern = this.ctx.createPattern(
+                                this.resizeImage(image, width, height),
+                                'repeat'
+                            ) as CanvasPattern;
+                            this.renderRepeat(path, pattern, x, y);
+                        }
                     });
                 }
             } else if (isLinearGradient(backgroundImage)) {

--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -14,7 +14,8 @@ import {
     parsePathForBorder,
     parsePathForBorderDoubleInner,
     parsePathForBorderDoubleOuter,
-    parsePathForBorderStroke
+    parsePathForBorderStroke,
+    BORDER_SIDE
 } from '../border';
 import {calculateBackgroundRendering, getBackgroundValueForIndex} from '../background';
 import {isDimensionToken} from '../../css/syntax/parser';
@@ -267,12 +268,19 @@ export class CanvasRenderer extends Renderer {
 
     renderReplacedElement(
         container: ReplacedElementContainer,
-        curves: BoundCurves,
+        curves: BoundCurves[],
         image: HTMLImageElement | HTMLCanvasElement
     ): void {
         if (image && container.intrinsicWidth > 0 && container.intrinsicHeight > 0) {
-            const box = contentBox(container);
-            const path = calculatePaddingBoxPath(curves);
+            const boxes = contentBox(container);
+            if (boxes.length !== 1) {
+                throw new Error(`Expecting a single bounding box but got ${boxes.length} for image replacement.`);
+            }
+            if (curves.length !== 1) {
+                throw new Error(`Expecting a single bounding box but got ${boxes.length} for image replacement.`);
+            }
+            const box = boxes[0];
+            const path = calculatePaddingBoxPath(curves[0]);
             this.path(path);
             this.ctx.save();
             this.ctx.clip();
@@ -334,55 +342,56 @@ export class CanvasRenderer extends Renderer {
 
             const canvas = await iframeRenderer.render(container.tree);
             if (container.width && container.height) {
+                const bound = container.bounds[0];
                 this.ctx.drawImage(
                     canvas,
                     0,
                     0,
                     container.width,
                     container.height,
-                    container.bounds.left,
-                    container.bounds.top,
-                    container.bounds.width,
-                    container.bounds.height
+                    bound.left,
+                    bound.top,
+                    bound.width,
+                    bound.height
                 );
             }
         }
 
         if (container instanceof InputElementContainer) {
-            const size = Math.min(container.bounds.width, container.bounds.height);
+            //Should use flat map if target is updated.
+            const size = Math.min(
+                ...container.bounds.map((b) => b.width).concat(container.bounds.map((b) => b.height))
+            );
 
             if (container.type === CHECKBOX) {
                 if (container.checked) {
-                    this.ctx.save();
-                    this.path([
-                        new Vector(container.bounds.left + size * 0.39363, container.bounds.top + size * 0.79),
-                        new Vector(container.bounds.left + size * 0.16, container.bounds.top + size * 0.5549),
-                        new Vector(container.bounds.left + size * 0.27347, container.bounds.top + size * 0.44071),
-                        new Vector(container.bounds.left + size * 0.39694, container.bounds.top + size * 0.5649),
-                        new Vector(container.bounds.left + size * 0.72983, container.bounds.top + size * 0.23),
-                        new Vector(container.bounds.left + size * 0.84, container.bounds.top + size * 0.34085),
-                        new Vector(container.bounds.left + size * 0.39363, container.bounds.top + size * 0.79)
-                    ]);
+                    container.bounds.forEach((bound) => {
+                        this.ctx.save();
+                        this.path([
+                            new Vector(bound.left + size * 0.39363, bound.top + size * 0.79),
+                            new Vector(bound.left + size * 0.16, bound.top + size * 0.5549),
+                            new Vector(bound.left + size * 0.27347, bound.top + size * 0.44071),
+                            new Vector(bound.left + size * 0.39694, bound.top + size * 0.5649),
+                            new Vector(bound.left + size * 0.72983, bound.top + size * 0.23),
+                            new Vector(bound.left + size * 0.84, bound.top + size * 0.34085),
+                            new Vector(bound.left + size * 0.39363, bound.top + size * 0.79)
+                        ]);
 
-                    this.ctx.fillStyle = asString(INPUT_COLOR);
-                    this.ctx.fill();
-                    this.ctx.restore();
+                        this.ctx.fillStyle = asString(INPUT_COLOR);
+                        this.ctx.fill();
+                        this.ctx.restore();
+                    });
                 }
             } else if (container.type === RADIO) {
                 if (container.checked) {
-                    this.ctx.save();
-                    this.ctx.beginPath();
-                    this.ctx.arc(
-                        container.bounds.left + size / 2,
-                        container.bounds.top + size / 2,
-                        size / 4,
-                        0,
-                        Math.PI * 2,
-                        true
-                    );
-                    this.ctx.fillStyle = asString(INPUT_COLOR);
-                    this.ctx.fill();
-                    this.ctx.restore();
+                    container.bounds.forEach((bound) => {
+                        this.ctx.save();
+                        this.ctx.beginPath();
+                        this.ctx.arc(bound.left + size / 2, bound.top + size / 2, size / 4, 0, Math.PI * 2, true);
+                        this.ctx.fillStyle = asString(INPUT_COLOR);
+                        this.ctx.fill();
+                        this.ctx.restore();
+                    });
                 }
             }
         }
@@ -397,7 +406,7 @@ export class CanvasRenderer extends Renderer {
             this.ctx.textBaseline = 'alphabetic';
             this.ctx.textAlign = canvasTextAlign(container.styles.textAlign);
 
-            const bounds = contentBox(container);
+            const bounds = contentBox(container)[0];
 
             let x = 0;
 
@@ -439,7 +448,11 @@ export class CanvasRenderer extends Renderer {
                     const url = (img as CSSURLImage).url;
                     try {
                         image = await this.context.cache.match(url);
-                        this.ctx.drawImage(image, container.bounds.left - (image.width + 10), container.bounds.top);
+                        this.ctx.drawImage(
+                            image,
+                            Math.min(...container.bounds.map((b) => b.left)) - (image.width + 10),
+                            Math.min(...container.bounds.map((b) => b.top))
+                        );
                     } catch (e) {
                         this.context.logger.error(`Error loading list-style-image ${url}`);
                     }
@@ -452,10 +465,12 @@ export class CanvasRenderer extends Renderer {
 
                 this.ctx.textBaseline = 'middle';
                 this.ctx.textAlign = 'right';
+                const width = Math.max(...container.bounds.map((b) => b.width));
                 const bounds = new Bounds(
-                    container.bounds.left,
-                    container.bounds.top + getAbsoluteValue(container.styles.paddingTop, container.bounds.width),
-                    container.bounds.width,
+                    Math.min(...container.bounds.map((b) => b.left)),
+                    Math.min(...container.bounds.map((b) => b.top)) +
+                        getAbsoluteValue(container.styles.paddingTop, width),
+                    width,
                     computeLineHeight(styles.lineHeight, styles.fontSize.number) / 2 + 1
                 );
 
@@ -586,7 +601,7 @@ export class CanvasRenderer extends Renderer {
         let index = container.styles.backgroundImage.length - 1;
         for (const backgroundImage of container.styles.backgroundImage.slice(0).reverse()) {
             if (backgroundImage.type === CSSImageType.URL) {
-                let image;
+                let image: HTMLImageElement | null = null;
                 const url = (backgroundImage as CSSURLImage).url;
                 try {
                     image = await this.context.cache.match(url);
@@ -595,75 +610,91 @@ export class CanvasRenderer extends Renderer {
                 }
 
                 if (image) {
-                    const [path, x, y, width, height] = calculateBackgroundRendering(container, index, [
+                    const areas = calculateBackgroundRendering(container, index, [
                         image.width,
                         image.height,
                         image.width / image.height
                     ]);
-                    const pattern = this.ctx.createPattern(
-                        this.resizeImage(image, width, height),
-                        'repeat'
-                    ) as CanvasPattern;
-                    this.renderRepeat(path, pattern, x, y);
+                    areas.forEach((area) => {
+                        const [path, x, y, width, height] = area;
+                        const pattern = this.ctx.createPattern(
+                            this.resizeImage(image!, width, height),
+                            'repeat'
+                        ) as CanvasPattern;
+                        this.renderRepeat(path, pattern, x, y);
+                    });
                 }
             } else if (isLinearGradient(backgroundImage)) {
-                const [path, x, y, width, height] = calculateBackgroundRendering(container, index, [null, null, null]);
-                const [lineLength, x0, x1, y0, y1] = calculateGradientDirection(backgroundImage.angle, width, height);
-
-                const canvas = document.createElement('canvas');
-                canvas.width = width;
-                canvas.height = height;
-                const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
-                const gradient = ctx.createLinearGradient(x0, y0, x1, y1);
-
-                processColorStops(backgroundImage.stops, lineLength).forEach((colorStop) =>
-                    gradient.addColorStop(colorStop.stop, asString(colorStop.color))
-                );
-
-                ctx.fillStyle = gradient;
-                ctx.fillRect(0, 0, width, height);
-                if (width > 0 && height > 0) {
-                    const pattern = this.ctx.createPattern(canvas, 'repeat') as CanvasPattern;
-                    this.renderRepeat(path, pattern, x, y);
-                }
-            } else if (isRadialGradient(backgroundImage)) {
-                const [path, left, top, width, height] = calculateBackgroundRendering(container, index, [
-                    null,
-                    null,
-                    null
-                ]);
-                const position = backgroundImage.position.length === 0 ? [FIFTY_PERCENT] : backgroundImage.position;
-                const x = getAbsoluteValue(position[0], width);
-                const y = getAbsoluteValue(position[position.length - 1], height);
-
-                const [rx, ry] = calculateRadius(backgroundImage, x, y, width, height);
-                if (rx > 0 && ry > 0) {
-                    const radialGradient = this.ctx.createRadialGradient(left + x, top + y, 0, left + x, top + y, rx);
-
-                    processColorStops(backgroundImage.stops, rx * 2).forEach((colorStop) =>
-                        radialGradient.addColorStop(colorStop.stop, asString(colorStop.color))
+                const areas = calculateBackgroundRendering(container, index, [null, null, null]);
+                areas.forEach((area) => {
+                    const [path, x, y, width, height] = area;
+                    const [lineLength, x0, x1, y0, y1] = calculateGradientDirection(
+                        backgroundImage.angle,
+                        width,
+                        height
                     );
 
-                    this.path(path);
-                    this.ctx.fillStyle = radialGradient;
-                    if (rx !== ry) {
-                        // transforms for elliptical radial gradient
-                        const midX = container.bounds.left + 0.5 * container.bounds.width;
-                        const midY = container.bounds.top + 0.5 * container.bounds.height;
-                        const f = ry / rx;
-                        const invF = 1 / f;
+                    const canvas = document.createElement('canvas');
+                    canvas.width = width;
+                    canvas.height = height;
+                    const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
+                    const gradient = ctx.createLinearGradient(x0, y0, x1, y1);
 
-                        this.ctx.save();
-                        this.ctx.translate(midX, midY);
-                        this.ctx.transform(1, 0, 0, f, 0, 0);
-                        this.ctx.translate(-midX, -midY);
+                    processColorStops(backgroundImage.stops, lineLength).forEach((colorStop) =>
+                        gradient.addColorStop(colorStop.stop, asString(colorStop.color))
+                    );
 
-                        this.ctx.fillRect(left, invF * (top - midY) + midY, width, height * invF);
-                        this.ctx.restore();
-                    } else {
-                        this.ctx.fill();
+                    ctx.fillStyle = gradient;
+                    ctx.fillRect(0, 0, width, height);
+                    if (width > 0 && height > 0) {
+                        const pattern = this.ctx.createPattern(canvas, 'repeat') as CanvasPattern;
+                        this.renderRepeat(path, pattern, x, y);
                     }
-                }
+                });
+            } else if (isRadialGradient(backgroundImage)) {
+                const areas = calculateBackgroundRendering(container, index, [null, null, null]);
+                const position = backgroundImage.position.length === 0 ? [FIFTY_PERCENT] : backgroundImage.position;
+                areas.forEach((area, areaindex) => {
+                    const [path, left, top, width, height] = area;
+                    const x = getAbsoluteValue(position[0], width);
+                    const y = getAbsoluteValue(position[position.length - 1], height);
+
+                    const [rx, ry] = calculateRadius(backgroundImage, x, y, width, height);
+                    if (rx > 0 && ry > 0) {
+                        const radialGradient = this.ctx.createRadialGradient(
+                            left + x,
+                            top + y,
+                            0,
+                            left + x,
+                            top + y,
+                            rx
+                        );
+
+                        processColorStops(backgroundImage.stops, rx * 2).forEach((colorStop) =>
+                            radialGradient.addColorStop(colorStop.stop, asString(colorStop.color))
+                        );
+
+                        this.path(path);
+                        this.ctx.fillStyle = radialGradient;
+                        if (rx !== ry) {
+                            // transforms for elliptical radial gradient
+                            const midX = container.bounds[areaindex].left + 0.5 * container.bounds[areaindex].width;
+                            const midY = container.bounds[areaindex].top + 0.5 * container.bounds[areaindex].height;
+                            const f = ry / rx;
+                            const invF = 1 / f;
+
+                            this.ctx.save();
+                            this.ctx.translate(midX, midY);
+                            this.ctx.transform(1, 0, 0, f, 0, 0);
+                            this.ctx.translate(-midX, -midY);
+
+                            this.ctx.fillRect(left, invF * (top - midY) + midY, width, height * invF);
+                            this.ctx.restore();
+                        } else {
+                            this.ctx.fill();
+                        }
+                    }
+                });
             }
             index--;
         }
@@ -701,88 +732,95 @@ export class CanvasRenderer extends Renderer {
             {style: styles.borderBottomStyle, color: styles.borderBottomColor, width: styles.borderBottomWidth},
             {style: styles.borderLeftStyle, color: styles.borderLeftColor, width: styles.borderLeftWidth}
         ];
+        for (const curve of paint.curves) {
+            const backgroundPaintingArea = calculateBackgroundCurvedPaintingArea(
+                getBackgroundValueForIndex(styles.backgroundClip, 0),
+                curve
+            );
 
-        const backgroundPaintingArea = calculateBackgroundCurvedPaintingArea(
-            getBackgroundValueForIndex(styles.backgroundClip, 0),
-            paint.curves
-        );
+            if (hasBackground || styles.boxShadow.length) {
+                this.ctx.save();
+                this.path(backgroundPaintingArea);
+                this.ctx.clip();
 
-        if (hasBackground || styles.boxShadow.length) {
-            this.ctx.save();
-            this.path(backgroundPaintingArea);
-            this.ctx.clip();
-
-            if (!isTransparent(styles.backgroundColor)) {
-                this.ctx.fillStyle = asString(styles.backgroundColor);
-                this.ctx.fill();
-            }
-
-            await this.renderBackgroundImage(paint.container);
-
-            this.ctx.restore();
-
-            styles.boxShadow
-                .slice(0)
-                .reverse()
-                .forEach((shadow) => {
-                    this.ctx.save();
-                    const borderBoxArea = calculateBorderBoxPath(paint.curves);
-                    const maskOffset = shadow.inset ? 0 : MASK_OFFSET;
-                    const shadowPaintingArea = transformPath(
-                        borderBoxArea,
-                        -maskOffset + (shadow.inset ? 1 : -1) * shadow.spread.number,
-                        (shadow.inset ? 1 : -1) * shadow.spread.number,
-                        shadow.spread.number * (shadow.inset ? -2 : 2),
-                        shadow.spread.number * (shadow.inset ? -2 : 2)
-                    );
-
-                    if (shadow.inset) {
-                        this.path(borderBoxArea);
-                        this.ctx.clip();
-                        this.mask(shadowPaintingArea);
-                    } else {
-                        this.mask(borderBoxArea);
-                        this.ctx.clip();
-                        this.path(shadowPaintingArea);
-                    }
-
-                    this.ctx.shadowOffsetX = shadow.offsetX.number + maskOffset;
-                    this.ctx.shadowOffsetY = shadow.offsetY.number;
-                    this.ctx.shadowColor = asString(shadow.color);
-                    this.ctx.shadowBlur = shadow.blur.number;
-                    this.ctx.fillStyle = shadow.inset ? asString(shadow.color) : 'rgba(0,0,0,1)';
-
+                if (!isTransparent(styles.backgroundColor)) {
+                    this.ctx.fillStyle = asString(styles.backgroundColor);
                     this.ctx.fill();
-                    this.ctx.restore();
-                });
-        }
-
-        let side = 0;
-        for (const border of borders) {
-            if (border.style !== BORDER_STYLE.NONE && !isTransparent(border.color) && border.width > 0) {
-                if (border.style === BORDER_STYLE.DASHED) {
-                    await this.renderDashedDottedBorder(
-                        border.color,
-                        border.width,
-                        side,
-                        paint.curves,
-                        BORDER_STYLE.DASHED
-                    );
-                } else if (border.style === BORDER_STYLE.DOTTED) {
-                    await this.renderDashedDottedBorder(
-                        border.color,
-                        border.width,
-                        side,
-                        paint.curves,
-                        BORDER_STYLE.DOTTED
-                    );
-                } else if (border.style === BORDER_STYLE.DOUBLE) {
-                    await this.renderDoubleBorder(border.color, border.width, side, paint.curves);
-                } else {
-                    await this.renderSolidBorder(border.color, side, paint.curves);
                 }
+
+                await this.renderBackgroundImage(paint.container);
+
+                this.ctx.restore();
+
+                styles.boxShadow
+                    .slice(0)
+                    .reverse()
+                    .forEach((shadow) => {
+                        this.ctx.save();
+                        const borderBoxArea = calculateBorderBoxPath(curve);
+                        const maskOffset = shadow.inset ? 0 : MASK_OFFSET;
+                        const shadowPaintingArea = transformPath(
+                            borderBoxArea,
+                            -maskOffset + (shadow.inset ? 1 : -1) * shadow.spread.number,
+                            (shadow.inset ? 1 : -1) * shadow.spread.number,
+                            shadow.spread.number * (shadow.inset ? -2 : 2),
+                            shadow.spread.number * (shadow.inset ? -2 : 2)
+                        );
+
+                        if (shadow.inset) {
+                            this.path(borderBoxArea);
+                            this.ctx.clip();
+                            this.mask(shadowPaintingArea);
+                        } else {
+                            this.mask(borderBoxArea);
+                            this.ctx.clip();
+                            this.path(shadowPaintingArea);
+                        }
+
+                        this.ctx.shadowOffsetX = shadow.offsetX.number + maskOffset;
+                        this.ctx.shadowOffsetY = shadow.offsetY.number;
+                        this.ctx.shadowColor = asString(shadow.color);
+                        this.ctx.shadowBlur = shadow.blur.number;
+                        this.ctx.fillStyle = shadow.inset ? asString(shadow.color) : 'rgba(0,0,0,1)';
+
+                        this.ctx.fill();
+                        this.ctx.restore();
+                    });
             }
-            side++;
+
+            let side = 0;
+            for (const border of borders) {
+                if (
+                    border.style !== BORDER_STYLE.NONE &&
+                    !isTransparent(border.color) &&
+                    border.width > 0 &&
+                    (curve.isFirstBoundOfElement || side !== BORDER_SIDE.LEFT) &&
+                    (curve.isLastBoundOfElement || side !== BORDER_SIDE.RIGHT)
+                ) {
+                    if (border.style === BORDER_STYLE.DASHED) {
+                        await this.renderDashedDottedBorder(
+                            border.color,
+                            border.width,
+                            side,
+                            curve,
+                            BORDER_STYLE.DASHED
+                        );
+                    } else if (border.style === BORDER_STYLE.DOTTED) {
+                        await this.renderDashedDottedBorder(
+                            border.color,
+                            border.width,
+                            side,
+                            curve,
+                            BORDER_STYLE.DOTTED
+                        );
+                    } else if (border.style === BORDER_STYLE.DOUBLE) {
+                        await this.renderDoubleBorder(border.color, border.width, side, curve);
+                    } else {
+                        await this.renderSolidBorder(border.color, side, curve);
+                    }
+                }
+                side++;
+            }
         }
     }
 

--- a/tests/reftests/text/background-on-multiline-span.html
+++ b/tests/reftests/text/background-on-multiline-span.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Background on multiline span</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <script type="text/javascript" src="../../test.js"></script>
+  <style>
+    div {
+      padding: 20px;
+      margin: 0 auto;
+      border: 5px solid black;
+    }
+  </style>
+</head>
+
+<body>
+  <div>
+    <p class="MsoNormal"><span style="font-weight: 700;"><span style="font-size: 12pt;">bold 1 no
+          highlighting&nbsp;</span></span><span style="font-weight: 700;"><span style="font-size: 12pt;">bold 2 still no
+          highlighting</span></span><span style="font-size: 12pt; color: black;">&nbsp;<span
+          style="background: rgb(200, 193, 49);border-radius: 16px;border: 1px solid;">test inline stuff with background
+          that is long enough to go onto a
+          second line. this is just some extra stuff to get it to flow over to a new line.</span>&nbsp; stuff that is
+        being blanked out. <span style="font-weight: 700;">More bold stuff that shouldn't be highlighted</span></span>
+    </p>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
**Summary**

This PR fixes/implements the following **bugs/features**

* Bug #2739 

Explain the **motivation** for making this change. What existing problem does the pull request solve?

elements with multiple bounding boxes are not correctly drawn. e.g. spans that flow to multiple lines. This causes backgrounds and borders to draw over previous elements.

**Test plan**

tests\reftests\text\background-on-multiline-span.html


Fixes #2739
closes #2739
