### PR TITLE
fix: calculateBackgroundRendering may return width or height less than 1

### DIFF
--- a/src/render/background.ts
+++ b/src/render/background.ts
@@ -58,7 +58,7 @@ export const calculateBackgroundRendering = (
         backgroundPositioningArea
     );
 
-    const [sizeWidth, sizeHeight] = backgroundImageSize;
+    let [sizeWidth, sizeHeight] = backgroundImageSize;
 
     const position = getAbsoluteValueForTuple(
         getBackgroundValueForIndex(container.styles.backgroundPosition, index),
@@ -76,6 +76,9 @@ export const calculateBackgroundRendering = (
 
     const offsetX = Math.round(backgroundPositioningArea.left + position[0]);
     const offsetY = Math.round(backgroundPositioningArea.top + position[1]);
+
+    sizeWidth = Math.max(1,sizeWidth)
+    sizeHeight = Math.max(1,sizeHeight)
 
     return [path, offsetX, offsetY, sizeWidth, sizeHeight];
 };


### PR DESCRIPTION
Bug: 
Bug reports:
Failed to execute 'createPattern' on 'CanvasRenderingContext2D': The image argument is a canvas element with a width or height of 0.

![image](https://user-images.githubusercontent.com/19306050/198582944-7fe2e109-2491-4c8c-bc1e-e675a92c23d7.png)

I console the value of width and height , find that the height is less than 1 caught this error
![image](https://user-images.githubusercontent.com/19306050/198588730-f0c74bca-5320-49b2-881d-47333e79a9a4.png)
![image](https://user-images.githubusercontent.com/19306050/198585797-17d2e75f-5a00-43be-bba0-ce14b47dd8d5.png)

calculateBackgroundRendering function return value width height may be less than 1, then createPattern function throw error 

**Closing issues**

Fixes #2981
