### PR TITLE
 fix: canvas origin is not at 0,0

### DIFF
--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -906,6 +906,7 @@ export class CanvasRenderer extends Renderer {
 
         await this.renderStack(stack);
         this.applyEffects([]);
+        this.ctx.translate(this.options.x, this.options.y);
         return this.canvas;
     }
 }


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] Bug 1
* [ ] Bug 2
* [ ] Feature 1
* [ ] Feature 2
* [ ] Breaking changes

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->
when i draw on the canvas returned by html2canvas,i want to start at(0,0). so i want to reset canvas's origin before return


**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #3033
