### PR TITLE
bug fix: solve the problem of incomplete svg rendering content

### DIFF
--- a/src/dom/replaced-elements/svg-element-container.ts
+++ b/src/dom/replaced-elements/svg-element-container.ts
@@ -8,16 +8,26 @@ export class SVGElementContainer extends ElementContainer {
     intrinsicHeight: number;
 
     constructor(context: Context, img: SVGSVGElement) {
-        super(context, img);
-        const s = new XMLSerializer();
-        const bounds = parseBounds(context, img);
-        img.setAttribute('width', `${bounds.width}px`);
-        img.setAttribute('height', `${bounds.height}px`);
+        super(context, img)
+        const s = new XMLSerializer()
+        const bounds = parseBounds(context, img)
+        let originPosition: string = img.style.position
+        img.setAttribute('width', `${bounds.width}px`)
+        img.setAttribute('height', `${bounds.height}px`)
+        
+        // fix: resolve missing svg serialized content
+        // if svg's tag has absolute position, when converting through serializeToString, it will result in missing SVG content.
+        // so, it is necessary to eliminate positioning before serialization.
+        img.style.position = 'initial'
 
-        this.svg = `data:image/svg+xml,${encodeURIComponent(s.serializeToString(img))}`;
-        this.intrinsicWidth = img.width.baseVal.value;
-        this.intrinsicHeight = img.height.baseVal.value;
+        this.svg = `data:image/svg+xml,${encodeURIComponent(s.serializeToString(img))}`
+        
+        // reset position
+        img.style.position = originPosition
+        
+        this.intrinsicWidth = img.width.baseVal.value
+        this.intrinsicHeight = img.height.baseVal.value
 
-        this.context.cache.addImage(this.svg);
+        this.context.cache.addImage(this.svg)
     }
 }


### PR DESCRIPTION
**Summary**

* [ bug ] SVG rendering using absolute positioning will produce missing [#3047](https://github.com/niklasvh/html2canvas/issues/3047)

Explain the **motivation** for making this change. What existing problem does the pull request solve?

dealing with the issue of incomplete rendering content when using 'position: absolute' to render SVG


**Test plan (required)**

> Sorry, I can't provide a unit test case for this problem, but I show the effect of the fix through a demo.

https://codesandbox.io/p/github/halo951/issue-html2canvas/master?file=%2Fsrc%2FApp.vue&workspace=%257B%2522activeFilepath%2522%253A%2522%252Fsrc%252FApp.vue%2522%252C%2522openFiles%2522%253A%255B%2522%252Fsrc%252FApp.vue%2522%255D%252C%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522gitSidebarPanel%2522%253A%2522COMMIT%2522%252C%2522spaces%2522%253A%257B%2522clg659avv000x356ijqjo89hc%2522%253A%257B%2522key%2522%253A%2522clg659avv000x356ijqjo89hc%2522%252C%2522name%2522%253A%2522Default%2522%252C%2522devtools%2522%253A%255B%257B%2522type%2522%253A%2522PREVIEW%2522%252C%2522taskId%2522%253A%2522dev%2522%252C%2522port%2522%253A5173%252C%2522key%2522%253A%2522clg659hbq005q356io4rkvhc4%2522%252C%2522isMinimized%2522%253Afalse%257D%255D%257D%257D%252C%2522currentSpace%2522%253A%2522clg659avv000x356ijqjo89hc%2522%252C%2522spacesOrder%2522%253A%255B%2522clg659avv000x356ijqjo89hc%2522%255D%252C%2522hideCodeEditor%2522%253Afalse%257D

**Code formatting**

**Closing issues**

Fixes [#3047](https://github.com/niklasvh/html2canvas/issues/3047)
