### PR TITLE
fix: text-shadow blur-radius doesn't match scale #2123

### DIFF
--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -200,7 +200,7 @@ export class CanvasRenderer extends Renderer {
                                     this.ctx.shadowColor = asString(textShadow.color);
                                     this.ctx.shadowOffsetX = textShadow.offsetX.number * this.options.scale;
                                     this.ctx.shadowOffsetY = textShadow.offsetY.number * this.options.scale;
-                                    this.ctx.shadowBlur = textShadow.blur.number;
+                                    this.ctx.shadowBlur = textShadow.blur.number * this.options.scale;;
 
                                     this.renderTextWithLetterSpacing(text, styles.letterSpacing, baseline);
                                 });


### PR DESCRIPTION
**Summary**

Fixing exactly this bug: https://github.com/niklasvh/html2canvas/issues/2123

**Test plan (required)**

The original ticket is self explanatory. I can provide a test case if that is deemed necessary.

**Closing issues**

closes #2123
