### PR TITLE
Fix for #2986

### DIFF
--- a/src/dom/document-cloner.ts
+++ b/src/dom/document-cloner.ts
@@ -220,7 +220,7 @@ export class DocumentCloner {
             clonedCanvas.width = canvas.width;
             clonedCanvas.height = canvas.height;
             const ctx = canvas.getContext('2d');
-            const clonedCtx = clonedCanvas.getContext('2d');
+            const clonedCtx = clonedCanvas.getContext('2d', { willReadFrequently: true });
             if (clonedCtx) {
                 if (!this.options.allowTaint && ctx) {
                     clonedCtx.putImageData(ctx.getImageData(0, 0, canvas.width, canvas.height), 0, 0);


### PR DESCRIPTION
Fix for "Canvas2D: Multiple readback operations using getImageData are faster with the willReadFrequently attribute set to true" warning in chrome browser

**Summary**
<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ ] Issue #2986 

**Closing issues**
Fixes #2986 
