### PR TITLE
Set the document clone iframe container's size via the style attribute

### DIFF
--- a/src/dom/document-cloner.ts
+++ b/src/dom/document-cloner.ts
@@ -503,6 +503,8 @@ const createIFrameContainer = (ownerDocument: Document, bounds: Bounds): HTMLIFr
     cloneIframeContainer.style.border = '0';
     cloneIframeContainer.width = bounds.width.toString();
     cloneIframeContainer.height = bounds.height.toString();
+    cloneIframeContainer.style.width = bounds.width.toString() + 'px';
+    cloneIframeContainer.style.height = bounds.height.toString() + 'px';
     cloneIframeContainer.scrolling = 'no'; // ios won't scroll without it
     cloneIframeContainer.setAttribute(IGNORE_ATTRIBUTE, 'true');
     ownerDocument.body.appendChild(cloneIframeContainer);


### PR DESCRIPTION
**Summary**

This PR fixes/implements the following **bugs/features**

* [x] Bug: CSS rules can override the iframe's size which compromises the screenshot

Some sites I used html2canvas on have a CSS rule like
```
body>iframe {
    position: absolute;
    width: 0;
    height: 0;
    overflow: hidden;
}
```
This CSS rule takes precedence over the the width and height attributes of the html2canvas iframe container. As a result, the document clone is rendered with a width and height of 0, so I get a blank, all-white screenshot.

This PR also sets the width and height of the iframe within the style attribute. The style attribute will take precedence over any CSS rules.

**Test plan (required)**

When I tried to run `npm test` locally I got this error:
```
Traceback (most recent call last):
  File "/Users/joey/.nvm/versions/node/v12.13.1/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/common.py", line 499, in <module>
    class OrderedSet(collections.MutableSet):                                           
AttributeError: module 'collections' has no attribute 'MutableSet'
```
I'm on macos Ventura 13.4.1 using npm 6.12.1 and node v12.13.1
