### PR TITLE
feat: added field withCredentials to xhr

### DIFF
--- a/src/core/cache-storage.ts
+++ b/src/core/cache-storage.ts
@@ -31,6 +31,7 @@ export interface ResourceOptions {
     useCORS: boolean;
     allowTaint: boolean;
     proxy?: string;
+    withCredentials?: boolean;
 }
 
 export class Cache {
@@ -145,6 +146,9 @@ export class Cache {
                     reject(`Failed to proxy resource ${key} with status code ${xhr.status}`);
                 }
             };
+            if (this._options.withCredentials) {
+                xhr.withCredentials = true;
+            }
 
             xhr.onerror = reject;
             const queryString = proxy.indexOf('?') > -1 ? '&' : '?';

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ const renderElement = async (element: HTMLElement, opts: Partial<Options>): Prom
     const contextOptions = {
         logging: opts.logging ?? true,
         cache: opts.cache,
+        withCredentials: opts.withCredentials,
         ...resourceOptions
     };
 


### PR DESCRIPTION
**Summary**
This pr adds field [withCredentials](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials) to the options.
**Usage example**
await html2canvas(document.body, { ... withCredentials: true, ... });
**Motivation**
Field must be set to true in case the proxy needs to receive and check cookies
