### PR TITLE
Fix error image use transfrom rotate style (Update stacking-context.ts )

### DIFF
--- a/src/render/stacking-context.ts
+++ b/src/render/stacking-context.ts
@@ -70,7 +70,6 @@ export class ElementPaint {
         while (parent) {
             const croplessEffects = parent.effects.filter((effect) => !isClipEffect(effect));
             if (inFlow || parent.container.styles.position !== POSITION.STATIC || !parent.parent) {
-                effects.unshift(...croplessEffects);
                 inFlow = [POSITION.ABSOLUTE, POSITION.FIXED].indexOf(parent.container.styles.position) === -1;
                 if (parent.container.styles.overflowX !== OVERFLOW.VISIBLE) {
                     const borderBox = calculateBorderBoxPath(parent.curves);
@@ -81,6 +80,7 @@ export class ElementPaint {
                         );
                     }
                 }
+                effects.unshift(...croplessEffects);
             } else {
                 effects.unshift(...croplessEffects);
             }


### PR DESCRIPTION



Fixed at https://github.com/niklasvh/html2canvas/pull/2663 once.



**Summary**

<!-- Summary of the PR -->

This PR fixesthe following **bugs**

* [ ] error on image use transfrom rotate style.

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

More info visite https://juejin.cn/post/7078594967970512932

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

css  transform: translateX(15%) rotate(-12deg);
![截屏2024-03-07 00 25 14](https://github.com/niklasvh/html2canvas/assets/1283383/6aaf3be5-04f3-4001-8a75-357da3067ea9)



**Code formatting**

-

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
