### PR TITLE
Allow types for onClone to return a promise

### DIFF
--- a/src/dom/document-cloner.ts
+++ b/src/dom/document-cloner.ts
@@ -27,7 +27,7 @@ import {DebuggerType, isDebugging} from '../core/debugger';
 
 export interface CloneOptions {
     ignoreElements?: (element: Element) => boolean;
-    onclone?: (document: Document, element: HTMLElement) => void;
+    onclone?: (document: Document, element: HTMLElement) => void | Promise<void>;
     allowTaint?: boolean;
 }
 


### PR DESCRIPTION
**Summary**

onClone is returned to a promise, so returning a promise already works, but the type is void. Typescript does not error returning a promise today, but sonar qube does find a "bug" because it thinks you return a promise where you shouldn't.
