### PR TITLE
Support for lch css

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "1.4.0",
+      "name": "html2canvas",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "css-line-break": "^2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html2canvas",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "html2canvas",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "css-line-break": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "dist/html2canvas.esm.js",
   "typings": "dist/types/index.d.ts",
   "browser": "dist/html2canvas.js",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "author": {
     "name": "Niklas von Hertzen",
     "email": "niklasvh@gmail.com",

--- a/src/css/syntax/parser.ts
+++ b/src/css/syntax/parser.ts
@@ -150,7 +150,9 @@ export const isIdentWithValue = (token: CSSValue, value: string): boolean =>
 
 export const nonWhiteSpace = (token: CSSValue): boolean => token.type !== TokenType.WHITESPACE_TOKEN;
 export const nonFunctionArgSeparator = (token: CSSValue): boolean =>
-    token.type !== TokenType.WHITESPACE_TOKEN && token.type !== TokenType.COMMA_TOKEN;
+    token.type !== TokenType.WHITESPACE_TOKEN &&
+    token.type !== TokenType.COMMA_TOKEN &&
+    token.type !== TokenType.DELIM_TOKEN;
 
 export const parseFunctionArgs = (tokens: CSSValue[]): CSSValue[][] => {
     const args: CSSValue[][] = [];

--- a/src/css/types/__tests__/color-tests.ts
+++ b/src/css/types/__tests__/color-tests.ts
@@ -40,6 +40,9 @@ describe('types', () => {
             it('hsl(.75turn, 60%, 70%)', () => strictEqual(parse('hsl(.75turn, 60%, 70%)'), parse('rgb(178,132,224)')));
             it('hsla(.75turn, 60%, 70%, 50%)', () =>
                 strictEqual(parse('hsl(.75turn, 60%, 70%, 50%)'), parse('rgba(178,132,224, 0.5)')));
+            it('lch(29.2345% 44.2 27 / 0.2)', () =>
+                strictEqual(parse('lch(29.2345% 44.2 27 / 0.2)'), pack(255, 148, 143, 0.2)));
+            it('lch(76.5 4.24 49.5)', () => strictEqual(parse('lch(76.5 4.24 49.5)'), pack(212, 182, 175, 1)));
         });
         describe('util', () => {
             describe('isTransparent', () => {


### PR DESCRIPTION
Notes:

npm tests passing
npm run format makes no changes

**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] Feature: Added support to lch css function at color/parser

Our project uses css _lch_ function to calculate background colours. in order to get screenshots of the components wich are using lch function we needed to add this functionality


**Test plan (required)**

Demonstrate how the issue/feature can be replicated. For most cases, simply adding an appropriate html/css template into the [reftests](https://github.com/niklasvh/html2canvas/tree/master/tests/reftests) should be sufficient. Please see other tests there for reference.

Use following styles in examples/existing_canvas.html, ensure the html2canvas works.

```html
    <style>
        canvas {
            border: 1px solid black;
        }
        button {
            clear: both;
            display: block;
        }
        #content {
            background: lch(76.5 4.24 49.5);
            padding: 50px 10px;
        }
    </style>
```

before PR:

![image](https://github.com/niklasvh/html2canvas/assets/12999095/a4dd6e37-50e1-49eb-b809-8be12bac3f02)


after PR:
![image](https://github.com/niklasvh/html2canvas/assets/12999095/f59c394e-9cbe-4ac9-b2fd-ad317e490bb7)


Please make sure that code adheres to the project code formatting. Running `npm run format` will automatically format your code correctly. **done**

