### PR TITLE
Fix the issue where TextNode does not render when it is an empty string and the line-height issue in non-Firefox browsers; also, fix the misalignment of textDecorationLine at high resolutions. 

### DIFF
--- a/src/dom/node-parser.ts
+++ b/src/dom/node-parser.ts
@@ -17,8 +17,8 @@ const LIST_OWNERS = ['OL', 'UL', 'MENU'];
 const parseNodeTree = (context: Context, node: Node, parent: ElementContainer, root: ElementContainer) => {
     for (let childNode = node.firstChild, nextNode; childNode; childNode = nextNode) {
         nextNode = childNode.nextSibling;
-
-        if (isTextNode(childNode) && childNode.data.trim().length > 0) {
+        // Fixes #2238 #1624 - Fix the issue of TextNode content being overlooked in rendering due to being perceived as blank by trim().
+        if (isTextNode(childNode) && childNode.data.length > 0) {
             parent.textNodes.push(new TextContainer(context, childNode, parent.styles));
         } else if (isElementNode(childNode)) {
             if (isSlotElement(childNode) && childNode.assignedNodes) {

--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -146,7 +146,16 @@ export class CanvasRenderer extends Renderer {
 
     renderTextWithLetterSpacing(text: TextBounds, letterSpacing: number, baseline: number): void {
         if (letterSpacing === 0) {
-            this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + baseline);
+            // 修复 Chrome 中，数字字符上移的问题。
+            // https://github.com/niklasvh/html2canvas/issues/2107#issuecomment-692462900
+            if (navigator.userAgent.indexOf('Firefox') === -1){
+                // non-Firefox browser add this
+                this.ctx.textBaseline = 'ideographic';
+                this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + text.bounds.height);
+                // this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + baseline);
+            } else {
+                this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + baseline);
+            }
         } else {
             const letters = segmentGraphemes(text.text);
             letters.reduce((left, letter) => {

--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -188,7 +188,7 @@ export class CanvasRenderer extends Renderer {
         this.ctx.direction = styles.direction === DIRECTION.RTL ? 'rtl' : 'ltr';
         this.ctx.textAlign = 'left';
         this.ctx.textBaseline = 'alphabetic';
-        const {baseline, middle} = this.fontMetrics.getMetrics(fontFamily, fontSize);
+        const {baseline} = this.fontMetrics.getMetrics(fontFamily, fontSize);
         const paintOrder = styles.paintOrder;
 
         text.textBounds.forEach((text) => {

--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -149,10 +149,8 @@ export class CanvasRenderer extends Renderer {
             // Fixed an issue with characters moving up in non-Firefox.
             // https://github.com/niklasvh/html2canvas/issues/2107#issuecomment-692462900
             if (navigator.userAgent.indexOf('Firefox') === -1){
-                // non-Firefox browser add this
                 this.ctx.textBaseline = 'ideographic';
                 this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + text.bounds.height);
-                // this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + baseline);
             } else {
                 this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + baseline);
             }

--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -146,16 +146,7 @@ export class CanvasRenderer extends Renderer {
 
     renderTextWithLetterSpacing(text: TextBounds, letterSpacing: number, baseline: number): void {
         if (letterSpacing === 0) {
-            // 修复 Chrome 中，数字字符上移的问题。
-            // https://github.com/niklasvh/html2canvas/issues/2107#issuecomment-692462900
-            if (navigator.userAgent.indexOf('Firefox') === -1){
-                // non-Firefox browser add this
-                this.ctx.textBaseline = 'ideographic';
-                this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + text.bounds.height);
-                // this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + baseline);
-            } else {
-                this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + baseline);
-            }
+            this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + baseline);
         } else {
             const letters = segmentGraphemes(text.text);
             letters.reduce((left, letter) => {
@@ -223,17 +214,35 @@ export class CanvasRenderer extends Renderer {
                         if (styles.textDecorationLine.length) {
                             this.ctx.fillStyle = asString(styles.textDecorationColor || styles.color);
                             styles.textDecorationLine.forEach((textDecorationLine) => {
-                                var fillHeight = 1;
-                                // High-resolution x-axis positioning errors due to scaling can be corrected by using the relative height values of elements. On high-resolution displays, scaling can introduce inaccuracies in x-axis positioning. By referencing the relative height values of elements, these errors can be rectified, achieving more precise display accuracy.
                                 switch (textDecorationLine) {
                                     case TEXT_DECORATION_LINE.UNDERLINE:
-                                        this.ctx.fillRect(text.bounds.left, text.bounds.top + text.bounds.height - fillHeight, text.bounds.width, fillHeight);
+                                        // Draws a line at the baseline of the font
+                                        // TODO As some browsers display the line as more than 1px if the font-size is big,
+                                        // need to take that into account both in position and size
+                                        this.ctx.fillRect(
+                                            text.bounds.left,
+                                            Math.round(text.bounds.top + baseline),
+                                            text.bounds.width,
+                                            1
+                                        );
+
                                         break;
                                     case TEXT_DECORATION_LINE.OVERLINE:
-                                        this.ctx.fillRect(text.bounds.left, text.bounds.top , text.bounds.width, fillHeight);
+                                        this.ctx.fillRect(
+                                            text.bounds.left,
+                                            Math.round(text.bounds.top),
+                                            text.bounds.width,
+                                            1
+                                        );
                                         break;
                                     case TEXT_DECORATION_LINE.LINE_THROUGH:
-                                        this.ctx.fillRect(text.bounds.left, text.bounds.top + (text.bounds.height / 2 - fillHeight / 2), text.bounds.width, fillHeight);
+                                        // TODO try and find exact position for line-through
+                                        this.ctx.fillRect(
+                                            text.bounds.left,
+                                            Math.ceil(text.bounds.top + middle),
+                                            text.bounds.width,
+                                            1
+                                        );
                                         break;
                                 }
                             });

--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -223,35 +223,17 @@ export class CanvasRenderer extends Renderer {
                         if (styles.textDecorationLine.length) {
                             this.ctx.fillStyle = asString(styles.textDecorationColor || styles.color);
                             styles.textDecorationLine.forEach((textDecorationLine) => {
+                                var fillHeight = 1;
+                                // Fix the issue where textDecorationLine exhibits x-axis positioning errors on high-resolution devices due to varying devicePixelRatio, corrected by using relative values of element heights.
                                 switch (textDecorationLine) {
                                     case TEXT_DECORATION_LINE.UNDERLINE:
-                                        // Draws a line at the baseline of the font
-                                        // TODO As some browsers display the line as more than 1px if the font-size is big,
-                                        // need to take that into account both in position and size
-                                        this.ctx.fillRect(
-                                            text.bounds.left,
-                                            Math.round(text.bounds.top + baseline),
-                                            text.bounds.width,
-                                            1
-                                        );
-
+                                        this.ctx.fillRect(text.bounds.left, text.bounds.top + text.bounds.height - fillHeight, text.bounds.width, fillHeight);
                                         break;
                                     case TEXT_DECORATION_LINE.OVERLINE:
-                                        this.ctx.fillRect(
-                                            text.bounds.left,
-                                            Math.round(text.bounds.top),
-                                            text.bounds.width,
-                                            1
-                                        );
+                                        this.ctx.fillRect(text.bounds.left, text.bounds.top , text.bounds.width, fillHeight);
                                         break;
                                     case TEXT_DECORATION_LINE.LINE_THROUGH:
-                                        // TODO try and find exact position for line-through
-                                        this.ctx.fillRect(
-                                            text.bounds.left,
-                                            Math.ceil(text.bounds.top + middle),
-                                            text.bounds.width,
-                                            1
-                                        );
+                                        this.ctx.fillRect(text.bounds.left, text.bounds.top + (text.bounds.height / 2 - fillHeight / 2), text.bounds.width, fillHeight);
                                         break;
                                 }
                             });

--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -146,7 +146,7 @@ export class CanvasRenderer extends Renderer {
 
     renderTextWithLetterSpacing(text: TextBounds, letterSpacing: number, baseline: number): void {
         if (letterSpacing === 0) {
-            // 修复 Chrome 中，数字字符上移的问题。
+            // Fixed an issue with characters moving up in non-Firefox.
             // https://github.com/niklasvh/html2canvas/issues/2107#issuecomment-692462900
             if (navigator.userAgent.indexOf('Firefox') === -1){
                 // non-Firefox browser add this
@@ -223,17 +223,17 @@ export class CanvasRenderer extends Renderer {
                         if (styles.textDecorationLine.length) {
                             this.ctx.fillStyle = asString(styles.textDecorationColor || styles.color);
                             styles.textDecorationLine.forEach((textDecorationLine) => {
-                                var fillHeight = 1;
                                 // Fix the issue where textDecorationLine exhibits x-axis positioning errors on high-resolution devices due to varying devicePixelRatio, corrected by using relative values of element heights.
+                                var decorationLineHeight = 1;
                                 switch (textDecorationLine) {
                                     case TEXT_DECORATION_LINE.UNDERLINE:
-                                        this.ctx.fillRect(text.bounds.left, text.bounds.top + text.bounds.height - fillHeight, text.bounds.width, fillHeight);
+                                        this.ctx.fillRect(text.bounds.left, text.bounds.top + text.bounds.height - decorationLineHeight, text.bounds.width, decorationLineHeight);
                                         break;
                                     case TEXT_DECORATION_LINE.OVERLINE:
-                                        this.ctx.fillRect(text.bounds.left, text.bounds.top , text.bounds.width, fillHeight);
+                                        this.ctx.fillRect(text.bounds.left, text.bounds.top , text.bounds.width, decorationLineHeight);
                                         break;
                                     case TEXT_DECORATION_LINE.LINE_THROUGH:
-                                        this.ctx.fillRect(text.bounds.left, text.bounds.top + (text.bounds.height / 2 - fillHeight / 2), text.bounds.width, fillHeight);
+                                        this.ctx.fillRect(text.bounds.left, text.bounds.top + (text.bounds.height / 2 - decorationLineHeight / 2), text.bounds.width, decorationLineHeight);
                                         break;
                                 }
                             });


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] Bug Fix the issue of TextNode content being overlooked in rendering due to being perceived as blank by trim().
* [x] Resolving the line-height issue of TextNode in non-Firefox browsers by utilizing element heights.
* [x] Correcting the issue of textDecorationLine displaying offsets on high-resolution devices by utilizing element heights.

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #2238 #1624 #2107
