### PR TITLE
feat: Add support for CSS Color Module Level 4 syntax color(...)

### DIFF
--- a/src/css/types/__tests__/color-tests.ts
+++ b/src/css/types/__tests__/color-tests.ts
@@ -40,6 +40,17 @@ describe('types', () => {
             it('hsl(.75turn, 60%, 70%)', () => strictEqual(parse('hsl(.75turn, 60%, 70%)'), parse('rgb(178,132,224)')));
             it('hsla(.75turn, 60%, 70%, 50%)', () =>
                 strictEqual(parse('hsl(.75turn, 60%, 70%, 50%)'), parse('rgba(178,132,224, 0.5)')));
+            
+            // CSS Color Module Level 4 color() function tests
+            it('color(srgb 0 0 0)', () => strictEqual(parse('color(srgb 0 0 0)'), pack(0, 0, 0, 1)));
+            it('color(srgb 1 1 1)', () => strictEqual(parse('color(srgb 1 1 1)'), pack(255, 255, 255, 1)));
+            it('color(srgb 0.5 0.5 0.5)', () => strictEqual(parse('color(srgb 0.5 0.5 0.5)'), pack(128, 128, 128, 1)));
+            it('color(srgb 0 0 0 / 0.5)', () => strictEqual(parse('color(srgb 0 0 0 / 0.5)'), pack(0, 0, 0, 0.5)));
+            it('color(srgb 0 0 0 / 0.85)', () => strictEqual(parse('color(srgb 0 0 0 / 0.85)'), pack(0, 0, 0, 0.85)));
+            it('color(srgb 1 0.5 0)', () => strictEqual(parse('color(srgb 1 0.5 0)'), pack(255, 128, 0, 1)));
+            it('color(display-p3 1 0 0)', () => strictEqual(parse('color(display-p3 1 0 0)'), pack(255, 0, 0, 1)));
+            it('color(srgb 100% 0% 50%)', () => strictEqual(parse('color(srgb 100% 0% 50%)'), pack(255, 0, 128, 1)));
+            it('color(srgb 50% 50% 50% / 25%)', () => strictEqual(parse('color(srgb 50% 50% 50% / 25%)'), pack(128, 128, 128, 0.25)));
         });
         describe('util', () => {
             describe('isTransparent', () => {


### PR DESCRIPTION
**Summary**

This PR adds support for CSS Color Module Level 4 syntax to html2canvas, specifically the `color()` function and relative color syntax with `rgb(from ...)` and `hsl(from ...)`.

This PR fixes/implements the following **bugs/features**

* [x] Bug: "Attempting to parse an unsupported color function" error when using CSS4 color syntax
* [x] Feature: Support for `color(srgb r g b / alpha)` syntax
* [ ] Breaking changes

**Motivation**

CSS Color Module Level 4 introduces new color functions and relative color syntax that are increasingly being used in modern web applications. Without this support, html2canvas throws errors when encountering these color functions, preventing proper rendering of elements that use this modern CSS syntax.

The specific issue was: